### PR TITLE
Release v3.2.0 - merge of design review + PR review fixes (#167-#212)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(freertos_cpp_wrappers
-    VERSION 3.1.0
+    VERSION 3.2.0
     LANGUAGES C CXX
 )
 
@@ -443,6 +443,39 @@ if(ENABLE_SIMULATION)
     add_subdirectory(tests/simulation)
 endif()
 
+endif() # NOT CMAKE_CROSSCOMPILING
+
+# =============================================================================
+# INSTALL RULES (host builds only - cross-compile installs are project-specific)
+# =============================================================================
+if(NOT CMAKE_CROSSCOMPILING)
+include(GNUInstallDirs)
+
+install(TARGETS freertos_cpp_wrappers
+    EXPORT freertos_cpp_wrappers-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/freertos_cpp_wrappersConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/freertos_cpp_wrappersConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freertos_cpp_wrappers
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/freertos_cpp_wrappersConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freertos_cpp_wrappers
+)
+
+install(EXPORT freertos_cpp_wrappers-targets
+    NAMESPACE freertos::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freertos_cpp_wrappers
+)
 endif() # NOT CMAKE_CROSSCOMPILING
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Include `<freertos.hpp>` to access version macros at compile time.
 |---------|---------|
 | **Safety-Critical Ready** | MISRA 2012 C compliant, suitable for functionally safe applications |
 | **Modern C++17** | RAII wrappers with move semantics, no raw pointers |
-| **Production Tested** | 592 tests, 95% branch coverage, used in commercial BMS systems |
+| **Production Tested** | 592+ tests, 95% branch coverage, used in commercial BMS systems |
 | **Zero Overhead** | Thin wrappers compile to efficient FreeRTOS calls |
 | **Dual API** | FreeRTOS-native and std-compatible interfaces |
 | **expected\<T,E\> Error Handling** | Type-safe error handling replacing error codes |
@@ -65,7 +65,7 @@ This library is ideal for:
 - Industrial automation controllers
 - Consumer electronics with safety requirements
 
-## Features (v3.0.1)
+## Features (v3.2.0)
 
 | Category | Feature | Description |
 |----------|---------|-------------|
@@ -94,7 +94,7 @@ Include(FetchContent)
 FetchContent_Declare(
   freertos_cpp_wrappers
   GIT_REPOSITORY https://github.com/aschokinatgmail/freertos_cpp_wrappers.git
-  GIT_TAG v3.0.1
+  GIT_TAG v3.2.0
 )
 FetchContent_MakeAvailable(freertos_cpp_wrappers)
 
@@ -114,6 +114,14 @@ git submodule add https://github.com/aschokinatgmail/freertos_cpp_wrappers.git t
 #include <freertos_task.hpp>
 #include <freertos_semaphore.hpp>
 ```
+
+## Known Limitations
+
+### Heap Allocation of `std::function` Callbacks
+
+The `task` and `timer` wrappers use `std::function<void()>` for their callback type. In embedded environments with constrained memory, `std::function` may allocate from the heap for large captures (it typically uses a small-object optimization for small lambdas, but this is implementation-defined and may throw `std::bad_alloc`).
+
+If heap-free callbacks are required, use `freertos::fixed_function<N>` — a fixed-capacity delegate that never allocates. It can be constructed from any callable and passed directly to wrapper constructors that accept callable parameters. See `freertos_fixed_function.hpp` for details.
 
 ## Code Examples
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,11 @@ services:
     working_dir: /project
     volumes:
       - .:/project
+      - build-test-cache:/project/build-test
     command:
       - bash
       - -c
       - |
-        rm -rf build-test && \
         cmake -B build-test \
           -DCMAKE_BUILD_TYPE=Debug \
           -DENABLE_CLANG_TIDY=OFF \
@@ -30,11 +30,11 @@ services:
     working_dir: /project
     volumes:
       - .:/project
+      - build-sim-cache:/project/build-sim
     command:
       - bash
       - -c
       - |
-        rm -rf build-sim && \
         cmake -B build-sim \
           -DCMAKE_BUILD_TYPE=Debug \
           -DENABLE_SIMULATION=ON \
@@ -52,12 +52,13 @@ services:
     working_dir: /project
     volumes:
       - .:/project
+      - build-cov-cache:/project/build-cov
     mem_limit: 8g
     command:
       - bash
       - -c
       - |
-        rm -rf build-cov && \
+        rm -rf build-cov/CMakeCache.txt build-cov/CMakeFiles && \
         cmake -B build-cov \
           -DCMAKE_BUILD_TYPE=Debug \
           -DENABLE_CLANG_TIDY=OFF \
@@ -66,7 +67,7 @@ services:
         cmake --build build-cov -j2 && \
         ctest --test-dir build-cov \
           --output-on-failure && \
-        gcovr --filter 'include/' --filter 'src/' --gcov-ignore-parse-errors negative_hits.warn --print-summary build-cov
+        gcovr --filter 'include/' --filter 'src/' --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors negative_hits.warn --print-summary build-cov
 
   # =======================================================================
   # Both mock + sim in one run (CI gate)
@@ -165,6 +166,12 @@ services:
     working_dir: /project
     volumes:
       - .:/project
+      - build-test-cache:/project/build-test
     stdin_open: true
     tty: true
     command: ["bash"]
+
+volumes:
+  build-test-cache:
+  build-sim-cache:
+  build-cov-cache:

--- a/include/freertos.hpp
+++ b/include/freertos.hpp
@@ -2,7 +2,7 @@
 @file freertos.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS C++ Wrappers Library main header
-@version 3.0.0
+@version 3.2.0
 @date 2024-04-12
 
 The MIT License (MIT)
@@ -46,11 +46,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "freertos_expected.hpp"
 #include "freertos_external_allocator.hpp"
 #include "freertos_fixed_function.hpp"
+#include "freertos_heap.hpp"
 #include "freertos_isr_context.hpp"
 #include "freertos_isr_result.hpp"
 #include "freertos_latch.hpp"
 #include "freertos_lock.hpp"
 #include "freertos_message_buffer.hpp"
+#include "freertos_once_flag.hpp"
 #include "freertos_pend_call.hpp"
 #include "freertos_queue.hpp"
 #include "freertos_queue_set.hpp"
@@ -58,6 +60,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "freertos_shared_mutex.hpp"
 #include "freertos_shared_data.hpp"
 #include "freertos_span.hpp"
+#include "freertos_stream_batching_buffer.hpp"
 #include "freertos_stream_buffer.hpp"
 #include "freertos_strong_types.hpp"
 #include "freertos_sw_timer.hpp"

--- a/include/freertos_atomic.hpp
+++ b/include/freertos_atomic.hpp
@@ -2,7 +2,7 @@
 @file freertos_atomic.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS atomic_flag and atomic<T> polyfill with wait/notify support
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -42,6 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <FreeRTOS.h>
 #include <atomic>
 #include <cstddef>
+#include <queue.h>
 #include <semphr.h>
 #include <task.h>
 #include <type_traits>
@@ -82,17 +83,19 @@ public:
         return m_flag.load(order);
     }
 
-    void wait(bool old, std::memory_order order = std::memory_order_seq_cst) const {
+    [[nodiscard]] expected<void, error> wait(bool old, std::memory_order order = std::memory_order_seq_cst) const {
         if (m_flag.load(order) != old) {
-            return;
+            return {};
         }
         ensure_semaphore();
         if (!m_semaphore) {
-            return;
+            configASSERT(m_semaphore);
+            return unexpected<error>(error::out_of_memory);
         }
         while (m_flag.load(order) == old) {
             xSemaphoreTake(m_semaphore, portMAX_DELAY);
         }
+        return {};
     }
 
     void notify_one() noexcept {
@@ -108,14 +111,14 @@ public:
         if (!m_semaphore) {
             return;
         }
-        for (UBaseType_t i = 0;
-             i < FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS; i++) {
+        UBaseType_t count = uxSemaphoreGetCount(m_semaphore);
+        UBaseType_t available = FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS - count;
+        for (UBaseType_t i = 0; i < available; i++) {
             xSemaphoreGive(m_semaphore);
         }
     }
 
     isr_result<void> notify_one_isr() noexcept {
-        ensure_semaphore();
         if (!m_semaphore) {
             return {pdFALSE};
         }
@@ -125,13 +128,14 @@ public:
     }
 
     isr_result<void> notify_all_isr() noexcept {
-        ensure_semaphore();
         if (!m_semaphore) {
             return {pdFALSE};
         }
         isr_result<void> result{pdFALSE};
-        for (UBaseType_t i = 0;
-             i < FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS; i++) {
+        UBaseType_t count = uxQueueMessagesWaitingFromISR(
+            reinterpret_cast<QueueHandle_t>(m_semaphore));
+        UBaseType_t available = FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS - count;
+        for (UBaseType_t i = 0; i < available; i++) {
             BaseType_t woken = pdFALSE;
             xSemaphoreGiveFromISR(m_semaphore, &woken);
             if (woken) {
@@ -158,8 +162,9 @@ public:
         if (!m_semaphore) {
             return unexpected<error>(error::invalid_handle);
         }
-        for (UBaseType_t i = 0;
-             i < FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS; i++) {
+        UBaseType_t count = uxSemaphoreGetCount(m_semaphore);
+        UBaseType_t available = FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS - count;
+        for (UBaseType_t i = 0; i < available; i++) {
             xSemaphoreGive(m_semaphore);
         }
         return {};
@@ -224,14 +229,16 @@ public:
         return m_flag.load(order);
     }
 
-    void wait(bool old, std::memory_order order = std::memory_order_seq_cst) const {
+    [[nodiscard]] expected<void, error> wait(bool old, std::memory_order order = std::memory_order_seq_cst) const {
         if (m_flag.load(order) != old) {
-            return;
+            return {};
         }
         ensure_semaphore();
+        configASSERT(m_semaphore);
         while (m_flag.load(order) == old) {
             xSemaphoreTake(m_semaphore, portMAX_DELAY);
         }
+        return {};
     }
 
     void notify_one() noexcept {
@@ -241,24 +248,31 @@ public:
 
     void notify_all() noexcept {
         ensure_semaphore();
-        for (UBaseType_t i = 0;
-             i < FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS; i++) {
+        UBaseType_t count = uxSemaphoreGetCount(m_semaphore);
+        UBaseType_t available = FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS - count;
+        for (UBaseType_t i = 0; i < available; i++) {
             xSemaphoreGive(m_semaphore);
         }
     }
 
     isr_result<void> notify_one_isr() noexcept {
-        ensure_semaphore();
+        if (!m_semaphore) {
+            return {pdFALSE};
+        }
         isr_result<void> result{pdFALSE};
         xSemaphoreGiveFromISR(m_semaphore, &result.higher_priority_task_woken);
         return result;
     }
 
     isr_result<void> notify_all_isr() noexcept {
-        ensure_semaphore();
+        if (!m_semaphore) {
+            return {pdFALSE};
+        }
         isr_result<void> result{pdFALSE};
-        for (UBaseType_t i = 0;
-             i < FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS; i++) {
+        UBaseType_t count = uxQueueMessagesWaitingFromISR(
+            reinterpret_cast<QueueHandle_t>(m_semaphore));
+        UBaseType_t available = FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS - count;
+        for (UBaseType_t i = 0; i < available; i++) {
             BaseType_t woken = pdFALSE;
             xSemaphoreGiveFromISR(m_semaphore, &woken);
             if (woken) {

--- a/include/freertos_atomic_wait.hpp
+++ b/include/freertos_atomic_wait.hpp
@@ -2,7 +2,7 @@
 @file freertos_atomic_wait.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS platform hooks for C++20 std::atomic::wait/notify_one/notify_all
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-21
 
 The MIT License (MIT)

--- a/include/freertos_clock.hpp
+++ b/include/freertos_clock.hpp
@@ -2,7 +2,7 @@
 @file freertos_clock.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS tick-based TrivialClock and tick conversion utilities
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-21
 
 The MIT License (MIT)

--- a/include/freertos_concepts.hpp
+++ b/include/freertos_concepts.hpp
@@ -2,7 +2,7 @@
 @file freertos_concepts.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief C++20 concepts for FreeRTOS wrapper template constraints
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-21
 
 The MIT License (MIT)

--- a/include/freertos_condition_variable.hpp
+++ b/include/freertos_condition_variable.hpp
@@ -2,7 +2,7 @@
 @file freertos_condition_variable.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS condition_variable_any wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -41,6 +41,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "freertos_isr_result.hpp"
 #include "freertos_thread_safety.hpp"
 #include <FreeRTOS.h>
+#include <atomic>
 #include <chrono>
 #include <ctime>
 #include <semphr.h>
@@ -62,17 +63,20 @@ class condition_variable_any {
   uint8_t m_semaphore_created{0};
 #endif
 
+  std::atomic<UBaseType_t> m_waiter_count{0};
+
 public:
   condition_variable_any() {
 #if configSUPPORT_STATIC_ALLOCATION
     m_semaphore =
         xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS, 0,
                                        &m_semaphore_storage);
+    configASSERT(m_semaphore != nullptr);
     m_semaphore_created = 1;
 #else
     m_semaphore = xSemaphoreCreateCounting(FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS, 0);
+    configASSERT(m_semaphore != nullptr);
 #endif
-    configASSERT(m_semaphore);
   }
 
   condition_variable_any(const condition_variable_any &) = delete;
@@ -85,6 +89,7 @@ public:
   }
 
   void notify_one() noexcept {
+    configASSERT(m_semaphore != nullptr);
     if (!m_semaphore) {
       return;
     }
@@ -92,11 +97,18 @@ public:
   }
 
   void notify_all() noexcept {
+    configASSERT(m_semaphore != nullptr);
     if (!m_semaphore) {
       return;
     }
-    for (UBaseType_t i = 0; i < FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS; i++) {
-      xSemaphoreGive(m_semaphore);
+    UBaseType_t count = m_waiter_count.load(std::memory_order_acquire);
+    if (count == 0) {
+      return;
+    }
+    UBaseType_t limit = FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS;
+    UBaseType_t gives = (count < limit) ? count : limit;
+    for (UBaseType_t i = 0; i < gives; i++) {
+      (void)xSemaphoreGive(m_semaphore);
     }
   }
 
@@ -131,7 +143,12 @@ public:
       return;
     }
     lock.unlock();
+    // Overflow protection: assert if max waiters exceeded
+    configASSERT(m_waiter_count.load(std::memory_order_acquire) <
+                 FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS);
+    m_waiter_count.fetch_add(1, std::memory_order_acq_rel);
     xSemaphoreTake(m_semaphore, portMAX_DELAY);
+    m_waiter_count.fetch_sub(1, std::memory_order_acq_rel);
     lock.lock();
   }
 
@@ -152,10 +169,15 @@ public:
       return std::cv_status::timeout;
     }
     lock.unlock();
+    // Overflow protection
+    configASSERT(m_waiter_count.load(std::memory_order_acquire) <
+                 FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS);
+    m_waiter_count.fetch_add(1, std::memory_order_acq_rel);
     auto ms = static_cast<TickType_t>(
         std::chrono::duration_cast<std::chrono::milliseconds>(rel_time).count());
     TickType_t ticks = pdMS_TO_TICKS(ms);
     BaseType_t result = xSemaphoreTake(m_semaphore, ticks);
+    m_waiter_count.fetch_sub(1, std::memory_order_acq_rel);
     lock.lock();
     return (result == pdTRUE) ? std::cv_status::no_timeout
                               : std::cv_status::timeout;
@@ -213,7 +235,7 @@ public:
     if (rc == pdTRUE) {
       return {};
     }
-    return unexpected<error>(error::semaphore_not_owned);
+    return unexpected<error>(error::would_block);
   }
 
   [[nodiscard]] expected<void, error> notify_all_ex() noexcept {

--- a/include/freertos_config.hpp
+++ b/include/freertos_config.hpp
@@ -2,7 +2,7 @@
 @file freertos_config.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief Feature detection header for FreeRTOS C++ Wrappers
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-21
 
 The MIT License (MIT)

--- a/include/freertos_event_group.hpp
+++ b/include/freertos_event_group.hpp
@@ -2,7 +2,7 @@
 @file freertos_event_group.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS event group wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)
@@ -55,6 +55,8 @@ class static_event_group_allocator {
   StaticEventGroup_t m_event_group_placeholder{};
 
 public:
+  static constexpr bool is_static = true;
+
   static_event_group_allocator() = default;
   ~static_event_group_allocator() = default;
   static_event_group_allocator(const static_event_group_allocator &) = delete;
@@ -82,6 +84,8 @@ public:
  */
 class dynamic_event_group_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_event_group_allocator &other) noexcept { (void)other; }
 
   EventGroupHandle_t create() { return xEventGroupCreate(); }
@@ -116,6 +120,7 @@ public:
   event_group(event_group &&other) noexcept
       : m_allocator(std::move(other.m_allocator)),
         m_event_group(other.m_event_group) {
+    configASSERT(!EventGroupAllocator::is_static);
     other.m_event_group = nullptr;
   }
   /**
@@ -131,6 +136,7 @@ public:
 
   event_group &operator=(const event_group &) = delete;
   event_group &operator=(event_group &&other) noexcept {
+    configASSERT(!EventGroupAllocator::is_static);
     if (this != &other) {
       swap(other);
     }
@@ -138,6 +144,7 @@ public:
   }
 
   void swap(event_group &other) noexcept {
+    configASSERT(!EventGroupAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_event_group, other.m_event_group);

--- a/include/freertos_expected.hpp
+++ b/include/freertos_expected.hpp
@@ -2,7 +2,7 @@
 @file freertos_expected.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief std::expected polyfill for FreeRTOS C++ Wrappers
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-16
 
 The MIT License (MIT)

--- a/include/freertos_external_allocator.hpp
+++ b/include/freertos_external_allocator.hpp
@@ -2,7 +2,7 @@
 @file freertos_external_allocator.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief External memory allocation for FreeRTOS C++ Wrappers
-@version 3.0.0
+@version 3.2.0
 @date 2026-04-16
 
 The MIT License (MIT)
@@ -84,6 +84,7 @@ template <typename Region> class external_semaphore_allocator {
   operator=(external_semaphore_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_semaphore_allocator(Region &region) : m_region(&region) {}
   external_semaphore_allocator(external_semaphore_allocator &&other) noexcept
       : m_region(other.m_region), m_memory(other.m_memory) {
@@ -158,6 +159,7 @@ class external_queue_allocator {
   external_queue_allocator &operator=(external_queue_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_queue_allocator(Region &region) : m_region(&region) {}
   external_queue_allocator(external_queue_allocator &&other) noexcept
       : m_region(other.m_region), m_struct_memory(other.m_struct_memory),
@@ -219,6 +221,7 @@ template <typename Region> class external_event_group_allocator {
   operator=(external_event_group_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_event_group_allocator(Region &region) : m_region(&region) {}
   external_event_group_allocator(
       external_event_group_allocator &&other) noexcept
@@ -270,6 +273,7 @@ class external_stream_buffer_allocator {
   operator=(external_stream_buffer_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_stream_buffer_allocator(Region &region)
       : m_region(&region) {}
   external_stream_buffer_allocator(
@@ -337,6 +341,7 @@ class external_message_buffer_allocator {
   operator=(external_message_buffer_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_message_buffer_allocator(Region &region)
       : m_region(&region) {}
   external_message_buffer_allocator(
@@ -399,6 +404,7 @@ template <typename Region> class external_sw_timer_allocator {
   operator=(external_sw_timer_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_sw_timer_allocator(Region &region) : m_region(&region) {}
   external_sw_timer_allocator(external_sw_timer_allocator &&other) noexcept
       : m_region(other.m_region), m_memory(other.m_memory) {
@@ -448,6 +454,7 @@ template <typename Region, size_t StackSize> class external_task_allocator {
   external_task_allocator &operator=(external_task_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_task_allocator(Region &region) : m_region(&region) {}
   external_task_allocator(external_task_allocator &&other) noexcept
       : m_region(other.m_region), m_task_memory(other.m_task_memory),
@@ -505,6 +512,7 @@ template <typename Region> class external_shared_mutex_allocator {
   operator=(external_shared_mutex_allocator &&) = delete;
 
 public:
+  static constexpr bool is_static = true;
   explicit external_shared_mutex_allocator(Region &region) : m_region(&region) {}
   external_shared_mutex_allocator(
       external_shared_mutex_allocator &&other) noexcept

--- a/include/freertos_external_threading.hpp
+++ b/include/freertos_external_threading.hpp
@@ -2,7 +2,7 @@
 @file freertos_external_threading.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief libc++ __external_threading backend for Clang/LLVM standard library
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-21
 
 The MIT License (MIT)

--- a/include/freertos_fixed_function.hpp
+++ b/include/freertos_fixed_function.hpp
@@ -2,7 +2,7 @@
 @file freertos_fixed_function.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief Fixed-capacity callback (SBO delegate) for heap-free task/timer callbacks
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -40,6 +40,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <cassert>
 #include <cstddef>
 #include <cstring>
+#include <exception>
 #include <type_traits>
 
 #ifndef configASSERT
@@ -156,6 +157,7 @@ public:
             m_copier(m_storage.data(), other.m_storage.data());
         } else if (!m_invoker) {
         } else {
+            configASSERT(false); // cannot copy fixed_function wrapping non-copyable callable
             m_invoker = nullptr;
             m_copier = nullptr;
             m_mover = nullptr;
@@ -167,7 +169,12 @@ public:
         : m_invoker(other.m_invoker), m_copier(other.m_copier),
           m_mover(other.m_mover), m_destroyer(other.m_destroyer) {
         if (m_mover) {
-            m_mover(m_storage.data(), other.m_storage.data());
+            try {
+                m_mover(m_storage.data(), other.m_storage.data());
+            } catch (...) {
+                configASSERT(false); // move of contained callable threw in noexcept context
+                std::terminate();
+            }
         }
         if (other.m_destroyer) {
             other.m_destroyer(other.m_storage.data());
@@ -188,6 +195,7 @@ public:
             if (m_copier) {
                 m_copier(m_storage.data(), other.m_storage.data());
             } else if (m_invoker) {
+                configASSERT(false); // cannot copy fixed_function wrapping non-copyable callable
                 m_invoker = nullptr;
                 m_copier = nullptr;
                 m_mover = nullptr;
@@ -205,7 +213,12 @@ public:
             m_mover = other.m_mover;
             m_destroyer = other.m_destroyer;
             if (m_mover) {
-                m_mover(m_storage.data(), other.m_storage.data());
+                try {
+                    m_mover(m_storage.data(), other.m_storage.data());
+                } catch (...) {
+                    configASSERT(false); // move of contained callable threw in noexcept context
+                    std::terminate();
+                }
             }
             if (other.m_destroyer) {
                 other.m_destroyer(other.m_storage.data());

--- a/include/freertos_gthr.hpp
+++ b/include/freertos_gthr.hpp
@@ -2,7 +2,7 @@
 @file freertos_gthr.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief GCC libstdc++ gthr-FreeRTOS threading backend
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-21
 
 The MIT License (MIT)
@@ -304,26 +304,23 @@ inline int __gthread_setspecific(__gthread_key_t key, const void *ptr) {
 
 inline int __gthread_cond_wait(__gthread_cond_t *cond,
                                 __gthread_mutex_t *mutex) {
-  cond->waiter_count++;
-  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  __atomic_fetch_add(&cond->waiter_count, 1, __ATOMIC_SEQ_CST);
   __gthread_mutex_unlock(mutex);
   xSemaphoreTake(cond->signal, portMAX_DELAY);
-  cond->waiter_count--;
+  __atomic_fetch_sub(&cond->waiter_count, 1, __ATOMIC_SEQ_CST);
   __gthread_mutex_lock(mutex);
   return 0;
 }
 
 inline int __gthread_cond_signal(__gthread_cond_t *cond) {
-  __atomic_thread_fence(__ATOMIC_SEQ_CST);
-  if (cond->waiter_count > 0) {
+  if (__atomic_load_n(&cond->waiter_count, __ATOMIC_SEQ_CST) > 0) {
     xSemaphoreGive(cond->signal);
   }
   return 0;
 }
 
 inline int __gthread_cond_broadcast(__gthread_cond_t *cond) {
-  __atomic_thread_fence(__ATOMIC_SEQ_CST);
-  int count = cond->waiter_count;
+  int count = __atomic_load_n(&cond->waiter_count, __ATOMIC_SEQ_CST);
   for (int i = 0; i < count; i++) {
     xSemaphoreGive(cond->signal);
   }
@@ -440,7 +437,7 @@ inline int __gthread_join(__gthread_t thread, void **value_ptr) {
     }
     vTaskDelay(1);
   } while (1);
-  vTaskDelete(thread);
+  // Task has already self-deleted; do not call vTaskDelete again.
   return 0;
 }
 

--- a/include/freertos_heap.hpp
+++ b/include/freertos_heap.hpp
@@ -2,7 +2,7 @@
 @file freertos_heap.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS heap integration: new/delete redirect and static memory callbacks
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -38,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <FreeRTOS.h>
 #include <task.h>
 
@@ -146,7 +147,7 @@ inline void vApplicationGetTimerTaskMemory(
 
 #ifdef FREERTOS_CPP_WRAPPERS_REDIRECT_NEW_DELETE
 
-void *operator new(size_t size) {
+void *operator new(size_t size) noexcept {
     return freertos::heap::allocate(size);
 }
 
@@ -154,7 +155,7 @@ void operator delete(void *ptr) noexcept {
     freertos::heap::deallocate(ptr);
 }
 
-void *operator new[](size_t size) {
+void *operator new[](size_t size) noexcept {
     return freertos::heap::allocate(size);
 }
 
@@ -177,5 +178,41 @@ void operator delete(void *ptr, size_t) noexcept {
 void operator delete[](void *ptr, size_t) noexcept {
     freertos::heap::deallocate(ptr);
 }
+
+#if __cplusplus >= 201703L
+
+void *operator new(size_t size, std::align_val_t align) noexcept {
+    return freertos::heap::allocate_with_alignment_check(static_cast<size_t>(align), size);
+}
+
+void *operator new[](size_t size, std::align_val_t align) noexcept {
+    return freertos::heap::allocate_with_alignment_check(static_cast<size_t>(align), size);
+}
+
+void *operator new(size_t size, std::align_val_t align, std::nothrow_t &) noexcept {
+    return freertos::heap::allocate_with_alignment_check(static_cast<size_t>(align), size);
+}
+
+void *operator new[](size_t size, std::align_val_t align, std::nothrow_t &) noexcept {
+    return freertos::heap::allocate_with_alignment_check(static_cast<size_t>(align), size);
+}
+
+void operator delete(void *ptr, std::align_val_t) noexcept {
+    freertos::heap::deallocate(ptr);
+}
+
+void operator delete[](void *ptr, std::align_val_t) noexcept {
+    freertos::heap::deallocate(ptr);
+}
+
+void operator delete(void *ptr, std::align_val_t, std::nothrow_t &) noexcept {
+    freertos::heap::deallocate(ptr);
+}
+
+void operator delete[](void *ptr, std::align_val_t, std::nothrow_t &) noexcept {
+    freertos::heap::deallocate(ptr);
+}
+
+#endif // __cplusplus >= 201703L
 
 #endif // FREERTOS_CPP_WRAPPERS_REDIRECT_NEW_DELETE

--- a/include/freertos_isr_context.hpp
+++ b/include/freertos_isr_context.hpp
@@ -2,7 +2,7 @@
 @file freertos_isr_context.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief ISR context detection utilities for FreeRTOS C++ Wrappers
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)

--- a/include/freertos_isr_result.hpp
+++ b/include/freertos_isr_result.hpp
@@ -2,7 +2,7 @@
 @file freertos_isr_result.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief ISR result type for FreeRTOS C++ Wrappers
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-16
 
 The MIT License (MIT)

--- a/include/freertos_latch.hpp
+++ b/include/freertos_latch.hpp
@@ -2,7 +2,7 @@
 @file freertos_latch.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS latch wrapper providing C++20 std::latch semantics
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -46,6 +46,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 namespace freertos {
 
 class latch {
+  static_assert(std::atomic<ptrdiff_t>::is_always_lock_free,
+                "latch requires lock-free atomic for ISR safety");
+
 public:
   static constexpr ptrdiff_t max() noexcept { return PTRDIFF_MAX; }
 
@@ -53,6 +56,8 @@ public:
       : m_semaphore{xSemaphoreCreateBinary()}, m_counter{expected} {
     configASSERT(m_semaphore);
   }
+
+  [[nodiscard]] bool valid() const noexcept { return m_semaphore != nullptr; }
 
   latch(const latch &) = delete;
   latch &operator=(const latch &) = delete;
@@ -67,9 +72,18 @@ public:
     if (update <= 0) {
       return;
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
-    if (prev == update) {
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return;
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
+    if (next == 0 && prev > 0) {
       if (m_semaphore) {
         xSemaphoreGive(m_semaphore);
       }
@@ -100,10 +114,19 @@ public:
     if (update <= 0) {
       return {pdFALSE};
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return {pdFALSE};
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
     isr_result<void> result{pdFALSE};
-    if (prev == update) {
+    if (next == 0 && prev > 0) {
       if (m_semaphore) {
         xSemaphoreGiveFromISR(m_semaphore, &result.higher_priority_task_woken);
       }
@@ -115,9 +138,18 @@ public:
     if (update <= 0) {
       return {};
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
-    if (prev == update) {
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return {};
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
+    if (next == 0 && prev > 0) {
       if (!m_semaphore) {
         return unexpected<error>(error::invalid_handle);
       }
@@ -135,11 +167,20 @@ public:
     if (update <= 0) {
       return {{}, pdFALSE};
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return {{}, pdFALSE};
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
     isr_result<expected<void, error>> result{
         unexpected<error>(error::semaphore_not_owned), pdFALSE};
-    if (prev == update) {
+    if (next == 0 && prev > 0) {
       if (!m_semaphore) {
         result.result = unexpected<error>(error::invalid_handle);
         return result;
@@ -166,6 +207,8 @@ namespace sa {
 
 template <ptrdiff_t N = 1> class latch_static {
   static_assert(N > 0, "latch expected count must be positive");
+  static_assert(std::atomic<ptrdiff_t>::is_always_lock_free,
+                "latch requires lock-free atomic for ISR safety");
 
   StaticSemaphore_t m_semaphore_placeholder{};
   SemaphoreHandle_t m_semaphore{nullptr};
@@ -178,6 +221,8 @@ public:
       : m_semaphore{xSemaphoreCreateBinaryStatic(&m_semaphore_placeholder)} {
     configASSERT(m_semaphore);
   }
+
+  [[nodiscard]] bool valid() const noexcept { return m_semaphore != nullptr; }
 
   latch_static(const latch_static &) = delete;
   latch_static &operator=(const latch_static &) = delete;
@@ -192,9 +237,18 @@ public:
     if (update <= 0) {
       return;
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
-    if (prev == update) {
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return;
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
+    if (next == 0 && prev > 0) {
       xSemaphoreGive(m_semaphore);
     }
   }
@@ -220,10 +274,19 @@ public:
     if (update <= 0) {
       return {pdFALSE};
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return {pdFALSE};
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
     isr_result<void> result{pdFALSE};
-    if (prev == update) {
+    if (next == 0 && prev > 0) {
       xSemaphoreGiveFromISR(m_semaphore, &result.higher_priority_task_woken);
     }
     return result;
@@ -233,9 +296,18 @@ public:
     if (update <= 0) {
       return {};
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
-    if (prev == update) {
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return {};
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
+    if (next == 0 && prev > 0) {
       auto rc = xSemaphoreGive(m_semaphore);
       if (rc == pdTRUE) {
         return {};
@@ -250,11 +322,20 @@ public:
     if (update <= 0) {
       return {{}, pdFALSE};
     }
-    auto prev =
-        m_counter.fetch_sub(update, std::memory_order_acq_rel);
+    ptrdiff_t prev;
+    ptrdiff_t next;
+    do {
+      prev = m_counter.load(std::memory_order_acquire);
+      if (prev <= 0) {
+        return {{}, pdFALSE};
+      }
+      next = prev > update ? prev - update : 0;
+    } while (!m_counter.compare_exchange_weak(prev, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
     isr_result<expected<void, error>> result{
         unexpected<error>(error::semaphore_not_owned), pdFALSE};
-    if (prev == update) {
+    if (next == 0 && prev > 0) {
       BaseType_t woken = pdFALSE;
       auto rc = xSemaphoreGiveFromISR(m_semaphore, &woken);
       result.higher_priority_task_woken = woken;

--- a/include/freertos_lock.hpp
+++ b/include/freertos_lock.hpp
@@ -2,7 +2,7 @@
 @file freertos_lock.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS shared_lock and Lockable concept compliance utilities
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -104,6 +104,7 @@ public:
 
   void lock() FREERTOS_ACQUIRE_SHARED() {
     configASSERT(m_mutex != nullptr);
+    configASSERT(!m_owns);
     if (m_mutex && !m_owns) {
       m_mutex->lock_shared();
       m_owns = true;
@@ -230,6 +231,7 @@ public:
 
   void lock() FREERTOS_ACQUIRE() {
     configASSERT(m_mutex != nullptr);
+    configASSERT(!m_owns);
     if (m_mutex && !m_owns) {
       m_mutex->lock();
       m_owns = true;

--- a/include/freertos_message_buffer.hpp
+++ b/include/freertos_message_buffer.hpp
@@ -2,7 +2,7 @@
 @file freertos_message_buffer.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS message buffer wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)
@@ -61,6 +61,8 @@ class dynamic_message_buffer_allocator_with_callback {
   void *m_receive_context;
 
 public:
+  static constexpr bool is_static = false;
+
   dynamic_message_buffer_allocator_with_callback(
       StreamBufferCallbackFunction_t send_callback, void *send_context,
       StreamBufferCallbackFunction_t receive_callback, void *receive_context)
@@ -101,6 +103,8 @@ class static_message_buffer_allocator_with_callback {
   std::array<uint8_t, MessageBufferSize> m_storage;
 
 public:
+  static constexpr bool is_static = true;
+
   static_message_buffer_allocator_with_callback(
       StreamBufferCallbackFunction_t send_callback, void *send_context,
       StreamBufferCallbackFunction_t receive_callback, void *receive_context)
@@ -146,6 +150,8 @@ template <size_t MessageBufferSize> class static_message_buffer_allocator {
   std::array<uint8_t, MessageBufferSize> m_storage;
 
 public:
+  static constexpr bool is_static = true;
+
   static_message_buffer_allocator() = default;
   ~static_message_buffer_allocator() = default;
   static_message_buffer_allocator(const static_message_buffer_allocator &) =
@@ -177,6 +183,8 @@ public:
  */
 template <size_t MessageBufferSize> class dynamic_message_buffer_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_message_buffer_allocator &other) noexcept { (void)other; }
 
   MessageBufferHandle_t create() {
@@ -215,6 +223,7 @@ public:
   message_buffer(message_buffer &&src) noexcept
       : m_allocator(std::move(src.m_allocator)),
         m_message_buffer(src.m_message_buffer) {
+    configASSERT(!MessageBufferAllocator::is_static);
     src.m_message_buffer = nullptr;
   }
   /**
@@ -230,6 +239,7 @@ public:
 
   message_buffer &operator=(const message_buffer &) = delete;
   message_buffer &operator=(message_buffer &&src) noexcept {
+    configASSERT(!MessageBufferAllocator::is_static);
     if (this != &src) {
       swap(src);
     }
@@ -237,6 +247,7 @@ public:
   }
 
   void swap(message_buffer &other) noexcept {
+    configASSERT(!MessageBufferAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_message_buffer, other.m_message_buffer);

--- a/include/freertos_once_flag.hpp
+++ b/include/freertos_once_flag.hpp
@@ -2,7 +2,7 @@
 @file freertos_once_flag.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS call_once / once_flag wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -43,7 +43,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <semphr.h>
 #include <utility>
 
+class OnceFlagTest;
+
 namespace freertos {
+
+#ifndef FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS
+#define FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS 8
+#endif
 
 class once_flag {
 public:
@@ -62,26 +68,31 @@ private:
 
 #if configSUPPORT_STATIC_ALLOCATION
     mutable StaticSemaphore_t m_semaphore_storage{};
-    mutable uint8_t m_semaphore_created{0};
+    mutable std::atomic<uint8_t> m_semaphore_created{0};
 #endif
 
     template <typename Callable, typename... Args>
     friend void call_once(once_flag &, Callable &&, Args &&...);
 
+    friend class ::OnceFlagTest;
+
     void ensure_semaphore() const {
         if (m_semaphore == nullptr) {
-            taskENTER_CRITICAL();
+            vTaskSuspendAll();
             if (m_semaphore == nullptr) {
 #if configSUPPORT_STATIC_ALLOCATION
-                if (m_semaphore_created == 0) {
-                    m_semaphore = xSemaphoreCreateBinaryStatic(&m_semaphore_storage);
-                    m_semaphore_created = 1;
+                if (m_semaphore_created.load(std::memory_order_acquire) == 0) {
+                    m_semaphore = xSemaphoreCreateCountingStatic(
+                        FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0,
+                        &m_semaphore_storage);
+                    m_semaphore_created.store(1, std::memory_order_release);
                 }
 #else
-                m_semaphore = xSemaphoreCreateBinary();
+                m_semaphore = xSemaphoreCreateCounting(
+                    FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0);
 #endif
             }
-            taskEXIT_CRITICAL();
+            (void)xTaskResumeAll();
         }
     }
 
@@ -98,14 +109,20 @@ private:
                 func(arg);
             } catch (...) {
                 m_state.store(0, std::memory_order_release);
-                xSemaphoreGive(m_semaphore);
+                for (uint8_t i = 0; i < FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS; ++i)
+                    xSemaphoreGive(m_semaphore);
                 throw;
             }
             m_state.store(2, std::memory_order_release);
-            xSemaphoreGive(m_semaphore);
+            for (uint8_t i = 0; i < FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS; ++i)
+                xSemaphoreGive(m_semaphore);
         } else {
             ensure_semaphore();
-            xSemaphoreTake(m_semaphore, portMAX_DELAY);
+            for (;;) {
+                xSemaphoreTake(m_semaphore, portMAX_DELAY);
+                if (m_state.load(std::memory_order_acquire) != 1)
+                    return;
+            }
         }
     }
 };
@@ -137,7 +154,7 @@ public:
     constexpr once_flag_static() noexcept = default;
     once_flag_static(const once_flag_static &) = delete;
     once_flag_static &operator=(const once_flag_static &) = delete;
-    ~once_flag_static() noexcept = default;
+    ~once_flag_static() noexcept { if (m_semaphore) vSemaphoreDelete(m_semaphore); }
 
     [[nodiscard]] bool is_initialized() const noexcept {
         return m_state.load(std::memory_order_acquire) == 2;
@@ -147,10 +164,12 @@ private:
     mutable SemaphoreHandle_t m_semaphore{nullptr};
     mutable std::atomic<uint8_t> m_state{0};
     StaticSemaphore_t m_semaphore_storage{};
-    mutable uint8_t m_semaphore_created{0};
+    mutable std::atomic<uint8_t> m_semaphore_created{0};
 
     template <typename Callable, typename... Args>
     friend void call_once(once_flag_static &, Callable &&, Args &&...);
+
+    friend class ::OnceFlagTest;
 
     void do_call(void (*func)(void *), void *arg) {
         uint8_t expected = 0;
@@ -161,30 +180,40 @@ private:
                                               std::memory_order_acq_rel,
                                               std::memory_order_acquire)) {
             taskENTER_CRITICAL();
-            if (m_semaphore_created == 0) {
+            if (m_semaphore_created.load(std::memory_order_acquire) == 0) {
                 m_semaphore =
-                    xSemaphoreCreateBinaryStatic(&m_semaphore_storage);
-                m_semaphore_created = 1;
+                    xSemaphoreCreateCountingStatic(
+                        FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0,
+                        &m_semaphore_storage);
+                m_semaphore_created.store(1, std::memory_order_release);
             }
             taskEXIT_CRITICAL();
             try {
                 func(arg);
             } catch (...) {
                 m_state.store(0, std::memory_order_release);
-                xSemaphoreGive(m_semaphore);
+                for (uint8_t i = 0; i < FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS; ++i)
+                    xSemaphoreGive(m_semaphore);
                 throw;
             }
             m_state.store(2, std::memory_order_release);
-            xSemaphoreGive(m_semaphore);
+            for (uint8_t i = 0; i < FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS; ++i)
+                xSemaphoreGive(m_semaphore);
         } else {
             taskENTER_CRITICAL();
-            if (m_semaphore_created == 0) {
+            if (m_semaphore_created.load(std::memory_order_acquire) == 0) {
                 m_semaphore =
-                    xSemaphoreCreateBinaryStatic(&m_semaphore_storage);
-                m_semaphore_created = 1;
+                    xSemaphoreCreateCountingStatic(
+                        FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0,
+                        &m_semaphore_storage);
+                m_semaphore_created.store(1, std::memory_order_release);
             }
             taskEXIT_CRITICAL();
-            xSemaphoreTake(m_semaphore, portMAX_DELAY);
+            for (;;) {
+                xSemaphoreTake(m_semaphore, portMAX_DELAY);
+                if (m_state.load(std::memory_order_acquire) != 1)
+                    return;
+            }
         }
     }
 };

--- a/include/freertos_pend_call.hpp
+++ b/include/freertos_pend_call.hpp
@@ -2,7 +2,7 @@
 @file freertos_pend_call.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS pend_call (deferred function execution from ISR) wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)

--- a/include/freertos_queue.hpp
+++ b/include/freertos_queue.hpp
@@ -2,7 +2,7 @@
 @file freertos_queue.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS queue wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)

--- a/include/freertos_queue_set.hpp
+++ b/include/freertos_queue_set.hpp
@@ -2,7 +2,7 @@
 @file freertos_queue_set.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS queue set wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-17
 
 The MIT License (MIT)

--- a/include/freertos_semaphore.hpp
+++ b/include/freertos_semaphore.hpp
@@ -2,7 +2,7 @@
 @file freertos_semaphore.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS semaphore wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)
@@ -58,6 +58,7 @@ class static_semaphore_allocator {
   StaticSemaphore_t m_semaphore_placeholder{};
 
 public:
+  static constexpr bool is_static = true;
   static_semaphore_allocator() = default;
   ~static_semaphore_allocator() = default;
   static_semaphore_allocator(const static_semaphore_allocator &) = delete;
@@ -94,6 +95,8 @@ public:
  */
 class dynamic_semaphore_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_semaphore_allocator &other) noexcept { (void)other; }
 
   SemaphoreHandle_t create_binary() { return xSemaphoreCreateBinary(); }
@@ -197,6 +200,7 @@ public:
   binary_semaphore(const binary_semaphore &) = delete;
   binary_semaphore(binary_semaphore &&src) noexcept
       : m_allocator(std::move(src.m_allocator)), m_semaphore(src.m_semaphore) {
+    configASSERT(!SemaphoreAllocator::is_static);
     src.m_semaphore = nullptr;
   }
   /**
@@ -212,6 +216,7 @@ public:
 
   binary_semaphore &operator=(const binary_semaphore &) = delete;
   binary_semaphore &operator=(binary_semaphore &&src) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     if (this != &src) {
       swap(src);
     }
@@ -219,6 +224,7 @@ public:
   }
 
   void swap(binary_semaphore &other) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_semaphore, other.m_semaphore);
@@ -383,6 +389,7 @@ public:
   counting_semaphore(counting_semaphore &&src) noexcept
       : m_allocator(std::move(src.m_allocator)),
         m_semaphore(src.m_semaphore) {
+    configASSERT(!SemaphoreAllocator::is_static);
     src.m_semaphore = nullptr;
   }
   /**
@@ -398,6 +405,7 @@ public:
 
   counting_semaphore &operator=(const counting_semaphore &) = delete;
   counting_semaphore &operator=(counting_semaphore &&src) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     if (this != &src) {
       swap(src);
     }
@@ -405,6 +413,7 @@ public:
   }
 
   void swap(counting_semaphore &other) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_semaphore, other.m_semaphore);
@@ -628,6 +637,7 @@ public:
   mutex(mutex &&src) noexcept
       : m_allocator(std::move(src.m_allocator)), m_semaphore(src.m_semaphore),
         m_locked(src.m_locked) {
+    configASSERT(!SemaphoreAllocator::is_static);
     configASSERT(!src.m_locked);
     src.m_semaphore = nullptr;
     src.m_locked = false;
@@ -645,6 +655,7 @@ public:
 
   mutex &operator=(const mutex &) = delete;
   mutex &operator=(mutex &&src) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     configASSERT(!m_locked);
     configASSERT(!src.m_locked);
     if (this != &src) {
@@ -654,6 +665,7 @@ public:
   }
 
   void swap(mutex &other) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_semaphore, other.m_semaphore);
@@ -681,17 +693,16 @@ public:
    * @brief Unlock the mutex from an ISR.
    * @ref https://www.freertos.org/a00124.html
    *
+   * WARNING: Mutexes must not be used from ISR context — FreeRTOS mutexes
+   * have priority inheritance that is incompatible with ISR. Use
+   * binary_semaphore instead.
+   *
    * @return isr_result<BaseType_t> containing the result and whether a
    * higher priority task was woken.
    */
   isr_result<BaseType_t> unlock_isr(void) {
-    isr_result<BaseType_t> result{pdFALSE, pdFALSE};
-    result.result =
-        xSemaphoreGiveFromISR(m_semaphore, &result.higher_priority_task_woken);
-    if (result.result) {
-      m_locked = false;
-    }
-    return result;
+    configASSERT(false);
+    return {pdFALSE, pdFALSE};
   }
   /**
    * @brief Lock the mutex.
@@ -712,17 +723,16 @@ public:
    * @brief Lock the mutex from an ISR.
    * @ref https://www.freertos.org/xSemaphoreTakeFromISR.html
    *
+   * WARNING: Mutexes must not be used from ISR context — FreeRTOS mutexes
+   * have priority inheritance that is incompatible with ISR. Use
+   * binary_semaphore instead.
+   *
    * @return isr_result<BaseType_t> containing the result and whether a
    * higher priority task was woken.
    */
   isr_result<BaseType_t> lock_isr(void) {
-    isr_result<BaseType_t> result{pdFALSE, pdFALSE};
-    result.result =
-        xSemaphoreTakeFromISR(m_semaphore, &result.higher_priority_task_woken);
-    if (result.result) {
-      m_locked = true;
-    }
-    return result;
+    configASSERT(false);
+    return {pdFALSE, pdFALSE};
   }
   /**
    * @brief Lock the mutex.
@@ -759,14 +769,14 @@ public:
     return unexpected<error>(ticks_to_wait == 0 ? error::would_block
                                                 : error::timeout);
   }
+  BaseType_t try_lock_isr() {
+    configASSERT(false);
+    return pdFALSE;
+  }
+
   [[nodiscard]] isr_result<expected<void, error>> lock_ex_isr() {
-    auto result = lock_isr();
-    isr_result<expected<void, error>> ret{unexpected<error>(error::would_block),
-                                          result.higher_priority_task_woken};
-    if (result.result == pdTRUE) {
-      ret.result = {};
-    }
-    return ret;
+    configASSERT(false);
+    return {unexpected<error>(error::would_block), pdFALSE};
   }
   [[nodiscard]] expected<void, error> unlock_ex() {
     auto rc = unlock();
@@ -776,14 +786,8 @@ public:
     return unexpected<error>(error::semaphore_not_owned);
   }
   [[nodiscard]] isr_result<expected<void, error>> unlock_ex_isr() {
-    auto result = unlock_isr();
-    isr_result<expected<void, error>> ret{
-        unexpected<error>(error::semaphore_not_owned),
-        result.higher_priority_task_woken};
-    if (result.result == pdTRUE) {
-      ret.result = {};
-    }
-    return ret;
+    configASSERT(false);
+    return {unexpected<error>(error::semaphore_not_owned), pdFALSE};
   }
   [[nodiscard]] expected<void, error> try_lock_ex() {
     auto rc = try_lock();
@@ -877,6 +881,7 @@ public:
       : m_allocator(std::move(src.m_allocator)),
         m_semaphore(src.m_semaphore),
         m_recursions_count(src.m_recursions_count) {
+    configASSERT(!SemaphoreAllocator::is_static);
     configASSERT(src.m_recursions_count == 0);
     src.m_semaphore = nullptr;
     src.m_recursions_count = 0;
@@ -894,6 +899,7 @@ public:
 
   recursive_mutex &operator=(const recursive_mutex &) = delete;
   recursive_mutex &operator=(recursive_mutex &&src) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     configASSERT(m_recursions_count == 0);
     configASSERT(src.m_recursions_count == 0);
     if (this != &src) {
@@ -903,6 +909,7 @@ public:
   }
 
   void swap(recursive_mutex &other) noexcept {
+    configASSERT(!SemaphoreAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_semaphore, other.m_semaphore);
@@ -1147,6 +1154,7 @@ template <typename Mutex> class FREERTOS_SCOPED_CAPABILITY lock_guard_isr {
   Mutex &m_mutex; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members):
                   // RAII design requires reference
   BaseType_t m_high_priority_task_woken{pdFALSE};
+  bool m_lock_acquired{false};
 
 public:
   /**
@@ -1157,6 +1165,7 @@ public:
   explicit lock_guard_isr(Mutex &mutex) FREERTOS_ACQUIRE("mutex")
       : m_mutex{mutex} {
     auto result = m_mutex.lock_isr();
+    m_lock_acquired = static_cast<bool>(result.result);
     m_high_priority_task_woken = result.higher_priority_task_woken;
   }
   /**
@@ -1164,8 +1173,10 @@ public:
    *
    */
   ~lock_guard_isr(void) FREERTOS_RELEASE() {
-    auto result = m_mutex.unlock_isr();
-    m_high_priority_task_woken = result.higher_priority_task_woken;
+    if (m_lock_acquired) {
+      auto result = m_mutex.unlock_isr();
+      m_high_priority_task_woken = result.higher_priority_task_woken;
+    }
   }
 
   // Delete copy and move operations for RAII safety
@@ -1188,7 +1199,7 @@ public:
    *
    * @return  true if the mutex is locked, otherwise false.
    */
-  bool locked(void) const { return m_mutex.locked(); }
+  bool locked(void) const { return m_lock_acquired && m_mutex.locked(); }
 };
 
 /**

--- a/include/freertos_shared_data.hpp
+++ b/include/freertos_shared_data.hpp
@@ -2,7 +2,7 @@
 @file freertos_shared_data.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief Thread-safe value wrapper for FreeRTOS C++ Wrappers
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -39,6 +39,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "freertos_config.hpp"
 #include "freertos_expected.hpp"
 #include "freertos_semaphore.hpp"
+#include "freertos_thread_safety.hpp"
 #include <type_traits>
 #include <utility>
 
@@ -46,7 +47,7 @@ namespace freertos {
 
 template <typename T, typename Mutex = freertos::mutex<freertos::dynamic_semaphore_allocator>>
 class shared_data {
-  T m_data{};
+  T m_data FREERTOS_GUARDED_BY(m_mutex){};
   mutable Mutex m_mutex;
 
 public:
@@ -58,30 +59,50 @@ public:
 
   T get() const {
     m_mutex.lock();
-    T result = m_data;
-    m_mutex.unlock();
-    return result;
+    try {
+      T result = m_data;
+      m_mutex.unlock();
+      return result;
+    } catch (...) {
+      m_mutex.unlock();
+      throw;
+    }
   }
 
   void set(const T &value) {
     m_mutex.lock();
-    m_data = value;
-    m_mutex.unlock();
+    try {
+      m_data = value;
+      m_mutex.unlock();
+    } catch (...) {
+      m_mutex.unlock();
+      throw;
+    }
   }
 
   void set(T &&value) {
     m_mutex.lock();
-    m_data = std::move(value);
-    m_mutex.unlock();
+    try {
+      m_data = std::move(value);
+      m_mutex.unlock();
+    } catch (...) {
+      m_mutex.unlock();
+      throw;
+    }
   }
 
   template <typename Fn>
   auto use(Fn &&fn) -> decltype(fn(std::declval<T &>())) {
     m_mutex.lock();
     try {
-      auto result = fn(m_data);
-      m_mutex.unlock();
-      return result;
+      if constexpr (std::is_void_v<decltype(fn(m_data))>) {
+        fn(m_data);
+        m_mutex.unlock();
+      } else {
+        auto result = fn(m_data);
+        m_mutex.unlock();
+        return result;
+      }
     } catch (...) {
       m_mutex.unlock();
       throw;
@@ -93,9 +114,14 @@ public:
     if (!rc.has_value()) {
       return unexpected<error>(rc.error());
     }
-    T result = m_data;
-    m_mutex.unlock();
-    return result;
+    try {
+      T result = m_data;
+      m_mutex.unlock();
+      return result;
+    } catch (...) {
+      m_mutex.unlock();
+      throw;
+    }
   }
 
   [[nodiscard]] expected<void, error> set_ex(const T &value) {
@@ -103,9 +129,14 @@ public:
     if (!rc.has_value()) {
       return unexpected<error>(rc.error());
     }
-    m_data = value;
-    m_mutex.unlock();
-    return {};
+    try {
+      m_data = value;
+      m_mutex.unlock();
+      return {};
+    } catch (...) {
+      m_mutex.unlock();
+      throw;
+    }
   }
 
   [[nodiscard]] expected<void, error> set_ex(T &&value) {
@@ -113,9 +144,14 @@ public:
     if (!rc.has_value()) {
       return unexpected<error>(rc.error());
     }
-    m_data = std::move(value);
-    m_mutex.unlock();
-    return {};
+    try {
+      m_data = std::move(value);
+      m_mutex.unlock();
+      return {};
+    } catch (...) {
+      m_mutex.unlock();
+      throw;
+    }
   }
 };
 

--- a/include/freertos_shared_mutex.hpp
+++ b/include/freertos_shared_mutex.hpp
@@ -2,7 +2,7 @@
 @file freertos_shared_mutex.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS shared_mutex wrapper providing C++20 std::shared_mutex semantics
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -62,6 +62,8 @@ class static_shared_mutex_allocator {
   StaticSemaphore_t m_reader_slots_placeholder{};
 
 public:
+  static constexpr bool is_static = true;
+
   static_shared_mutex_allocator() = default;
   ~static_shared_mutex_allocator() = default;
   static_shared_mutex_allocator(const static_shared_mutex_allocator &) = delete;
@@ -90,6 +92,8 @@ public:
 #if configSUPPORT_DYNAMIC_ALLOCATION
 class dynamic_shared_mutex_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_shared_mutex_allocator &other) noexcept { (void)other; }
 
   SemaphoreHandle_t create_mutex() { return xSemaphoreCreateMutex(); }

--- a/include/freertos_span.hpp
+++ b/include/freertos_span.hpp
@@ -2,7 +2,7 @@
 @file freertos_span.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief std::span polyfill for FreeRTOS C++ Wrappers
-@version 3.0.0
+@version 3.2.0
 @date 2026-04-16
 
 The MIT License (MIT)

--- a/include/freertos_stream_batching_buffer.hpp
+++ b/include/freertos_stream_batching_buffer.hpp
@@ -2,7 +2,7 @@
 @file freertos_stream_batching_buffer.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS stream batching buffer interface wrapper (V11.1.0+)
-@version 3.1.0
+@version 3.2.0
 @date 2026-04-22
 
 The MIT License (MIT)
@@ -63,6 +63,8 @@ class dynamic_stream_batching_buffer_allocator_with_callback {
   void *m_receive_context;
 
 public:
+  static constexpr bool is_static = false;
+
   dynamic_stream_batching_buffer_allocator_with_callback(
       StreamBufferCallbackFunction_t send_callback, void *send_context,
       StreamBufferCallbackFunction_t receive_callback, void *receive_context)
@@ -99,6 +101,8 @@ class static_stream_batching_buffer_allocator_with_callback {
   std::array<uint8_t, StreamBufferSize> m_storage;
 
 public:
+  static constexpr bool is_static = true;
+
   static_stream_batching_buffer_allocator_with_callback(
       StreamBufferCallbackFunction_t send_callback, void *send_context,
       StreamBufferCallbackFunction_t receive_callback, void *receive_context)
@@ -139,6 +143,8 @@ template <size_t StreamBufferSize> class static_stream_batching_buffer_allocator
   std::array<uint8_t, StreamBufferSize> m_storage;
 
 public:
+  static constexpr bool is_static = true;
+
   static_stream_batching_buffer_allocator() = default;
   ~static_stream_batching_buffer_allocator() = default;
   static_stream_batching_buffer_allocator(const static_stream_batching_buffer_allocator &) =
@@ -167,6 +173,8 @@ public:
 #if configSUPPORT_DYNAMIC_ALLOCATION
 template <size_t StreamBufferSize> class dynamic_stream_batching_buffer_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_stream_batching_buffer_allocator &other) noexcept { (void)other; }
 
   StreamBufferHandle_t create(size_t trigger_level_bytes = 1) {
@@ -197,6 +205,7 @@ public:
   stream_batching_buffer(stream_batching_buffer &&src) noexcept
       : m_allocator(std::move(src.m_allocator)),
         m_stream_buffer(src.m_stream_buffer) {
+    configASSERT(!StreamBatchingBufferAllocator::is_static);
     src.m_stream_buffer = nullptr;
   }
   ~stream_batching_buffer(void) {
@@ -207,6 +216,7 @@ public:
 
   stream_batching_buffer &operator=(const stream_batching_buffer &) = delete;
   stream_batching_buffer &operator=(stream_batching_buffer &&src) noexcept {
+    configASSERT(!StreamBatchingBufferAllocator::is_static);
     if (this != &src) {
       swap(src);
     }
@@ -214,6 +224,7 @@ public:
   }
 
   void swap(stream_batching_buffer &other) noexcept {
+    configASSERT(!StreamBatchingBufferAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_stream_buffer, other.m_stream_buffer);

--- a/include/freertos_stream_buffer.hpp
+++ b/include/freertos_stream_buffer.hpp
@@ -2,7 +2,7 @@
 @file freertos_stream_buffer.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS stream buffer interface wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)
@@ -62,6 +62,8 @@ class dynamic_stream_buffer_allocator_with_callback {
   void *m_receive_context;
 
 public:
+  static constexpr bool is_static = false;
+
   dynamic_stream_buffer_allocator_with_callback(
       StreamBufferCallbackFunction_t send_callback, void *send_context,
       StreamBufferCallbackFunction_t receive_callback, void *receive_context)
@@ -102,6 +104,8 @@ class static_stream_buffer_allocator_with_callback {
   std::array<uint8_t, StreamBufferSize> m_storage;
 
 public:
+  static constexpr bool is_static = true;
+
   static_stream_buffer_allocator_with_callback(
       StreamBufferCallbackFunction_t send_callback, void *send_context,
       StreamBufferCallbackFunction_t receive_callback, void *receive_context)
@@ -147,6 +151,8 @@ template <size_t StreamBufferSize> class static_stream_buffer_allocator {
   std::array<uint8_t, StreamBufferSize> m_storage;
 
 public:
+  static constexpr bool is_static = true;
+
   static_stream_buffer_allocator() = default;
   ~static_stream_buffer_allocator() = default;
   static_stream_buffer_allocator(const static_stream_buffer_allocator &) =
@@ -179,6 +185,8 @@ public:
  */
 template <size_t StreamBufferSize> class dynamic_stream_buffer_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_stream_buffer_allocator &other) noexcept { (void)other; }
 
   StreamBufferHandle_t create(size_t trigger_level_bytes = 1) {
@@ -220,6 +228,7 @@ public:
   stream_buffer(stream_buffer &&src) noexcept
       : m_allocator(std::move(src.m_allocator)),
         m_stream_buffer(src.m_stream_buffer) {
+    configASSERT(!StreamBufferAllocator::is_static);
     src.m_stream_buffer = nullptr;
   }
   /**
@@ -235,6 +244,7 @@ public:
 
   stream_buffer &operator=(const stream_buffer &) = delete;
   stream_buffer &operator=(stream_buffer &&src) noexcept {
+    configASSERT(!StreamBufferAllocator::is_static);
     if (this != &src) {
       swap(src);
     }
@@ -242,6 +252,7 @@ public:
   }
 
   void swap(stream_buffer &other) noexcept {
+    configASSERT(!StreamBufferAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_stream_buffer, other.m_stream_buffer);

--- a/include/freertos_strong_types.hpp
+++ b/include/freertos_strong_types.hpp
@@ -2,7 +2,7 @@
 @file freertos_strong_types.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief Strong typedefs for FreeRTOS primitive types
-@version 3.0.0
+@version 3.2.0
 @date 2026-04-16
 
 The MIT License (MIT)

--- a/include/freertos_sw_timer.hpp
+++ b/include/freertos_sw_timer.hpp
@@ -2,7 +2,7 @@
 @file freertos_sw_timer.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS software timer wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)
@@ -40,6 +40,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "freertos_isr_result.hpp"
 #include <FreeRTOS.h>
 #include <chrono>
+#include <atomic>
 #include <cstdbool>
 #include <ctime>
 #include <functional>
@@ -52,8 +53,6 @@ namespace freertos {
 
 #if configUSE_TIMERS
 
-using std::function;
-
 #if configSUPPORT_STATIC_ALLOCATION
 /**
  * @brief An allocator for the software timer that uses a static memory
@@ -64,6 +63,8 @@ class static_sw_timer_allocator {
   StaticTimer_t m_timer_placeholder{};
 
 public:
+  static constexpr bool is_static = true;
+
   static_sw_timer_allocator() = default;
   ~static_sw_timer_allocator() = default;
   static_sw_timer_allocator(const static_sw_timer_allocator &) = delete;
@@ -94,6 +95,8 @@ public:
  */
 class dynamic_sw_timer_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_sw_timer_allocator &other) noexcept { (void)other; }
 
   TimerHandle_t create(const char *name, const TickType_t period_ticks,
@@ -108,7 +111,7 @@ public:
  * @brief Timer callback routine type definition based on std::function.
  *
  */
-using timer_callback_t = function<void()>;
+using timer_callback_t = std::function<void()>;
 
 /**
  * @brief A wrapper for the FreeRTOS software timer.
@@ -118,11 +121,7 @@ using timer_callback_t = function<void()>;
 template <typename SwTimerAllocator> class timer {
   SwTimerAllocator m_allocator;
   timer_callback_t m_callback;
-  // Note: volatile is used as a single-core workaround to prevent compiler
-  // reordering of reads/writes between ISR and task contexts. On multi-core
-  // systems, stronger synchronization (std::atomic or critical sections)
-  // would be required. See issue #121.
-  volatile uint8_t m_started : 1;
+  std::atomic<bool> m_started{false};
   TimerHandle_t m_timer;
 
   // LCOV_EXCL_START - Internal FreeRTOS timer callback function
@@ -195,20 +194,22 @@ public:
   /**
    * @brief Move constructor that properly transfers timer ownership.
    *
-   * This constructor ensures that when a timer is moved, the source timer's
-   * handle is set to nullptr to prevent double deletion. Previously, the
-   * default move constructor would perform a shallow copy, causing both
-   * source and destination timers to share the same handle, leading to
-   * premature timer deletion when the source was destroyed.
+   * @warning Moving a **started** timer is undefined behavior. The timer
+   * daemon may fire concurrently and invoke the callback through the old
+   * `this` pointer (now invalid) or read `m_started` while it is being
+   * moved. Always stop the timer before moving it.
    *
    * @param src The source timer to move from (will be invalidated)
    */
   timer(timer &&src) noexcept
       : m_allocator(std::move(src.m_allocator)),
-        m_callback(std::move(src.m_callback)), m_started(src.m_started),
+        m_callback(std::move(src.m_callback)),
+        m_started{src.m_started.load(std::memory_order_acquire)},
         m_timer(src.m_timer) {
+    configASSERT(!SwTimerAllocator::is_static);
+    configASSERT(!src.m_started.load(std::memory_order_acquire)); // UB if started
     src.m_timer = nullptr;
-    src.m_started = false;
+    src.m_started.store(false, std::memory_order_release);
     if (m_timer) {
       vTimerSetTimerID(m_timer, this);
     }
@@ -227,6 +228,7 @@ public:
 
   timer &operator=(const timer &) = delete;
   timer &operator=(timer &&src) noexcept {
+    configASSERT(!SwTimerAllocator::is_static);
     if (this != &src) {
       if (src.m_timer) {
         auto rc = xTimerStop(src.m_timer, portMAX_DELAY);
@@ -234,7 +236,7 @@ public:
           auto name = pcTimerGetName(src.m_timer);
           auto period = xTimerGetPeriod(src.m_timer);
           auto auto_reload = uxTimerGetReloadMode(src.m_timer);
-          bool was_started = src.m_started;
+          bool was_started = src.m_started.load(std::memory_order_acquire);
 
           // Create new timer using source's allocator BEFORE modifying
           // either object, so we can roll back cleanly on failure.
@@ -252,11 +254,11 @@ public:
             xTimerDelete(src.m_timer, portMAX_DELAY);
             src.m_timer = nullptr;
             src.m_callback = nullptr;
-            m_started = false;
+            m_started.store(false, std::memory_order_release);
             if (was_started) {
               rc = xTimerStart(m_timer, portMAX_DELAY);
               if (rc == pdPASS) {
-                m_started = true;
+                m_started.store(true, std::memory_order_release);
               }
             }
           } else {
@@ -271,19 +273,21 @@ public:
           xTimerDelete(m_timer, portMAX_DELAY);
           m_timer = nullptr;
         }
-        m_started = false;
+        m_started.store(false, std::memory_order_release);
       }
     }
     return *this;
   }
 
   void swap(timer &other) noexcept {
+    configASSERT(!SwTimerAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_callback, other.m_callback);
-    const bool started_tmp = m_started;
-    m_started = other.m_started ? 1 : 0;
-    other.m_started = started_tmp ? 1 : 0;
+    const bool started_tmp = m_started.load(std::memory_order_acquire);
+    m_started.store(other.m_started.load(std::memory_order_acquire),
+                    std::memory_order_release);
+    other.m_started.store(started_tmp, std::memory_order_release);
     swap(m_timer, other.m_timer);
     if (m_timer) {
       vTimerSetTimerID(m_timer, this);
@@ -308,7 +312,7 @@ public:
     }
     auto rc = xTimerStart(m_timer, ticks_to_wait);
     if (rc) {
-      m_started = true;
+      m_started.store(true, std::memory_order_release);
     }
     return rc;
   }
@@ -342,7 +346,7 @@ public:
     result.result =
         xTimerStartFromISR(m_timer, &result.higher_priority_task_woken);
     if (result.result) {
-      m_started = true;
+      m_started.store(true, std::memory_order_release);
     }
     return result;
   }
@@ -359,7 +363,7 @@ public:
     }
     auto rc = xTimerStop(m_timer, ticks_to_wait);
     if (rc) {
-      m_started = false;
+      m_started.store(false, std::memory_order_release);
     }
     return rc;
   }
@@ -393,7 +397,7 @@ public:
     result.result =
         xTimerStopFromISR(m_timer, &result.higher_priority_task_woken);
     if (result.result) {
-      m_started = false;
+      m_started.store(false, std::memory_order_release);
     }
     return result;
   }

--- a/include/freertos_task.hpp
+++ b/include/freertos_task.hpp
@@ -2,7 +2,7 @@
 @file freertos_task.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief FreeRTOS task routines wrapper
-@version 3.1.0
+@version 3.2.0
 @date 2024-04-07
 
 The MIT License (MIT)
@@ -66,6 +66,8 @@ template <size_t StackSize> class static_task_allocator {
   StaticTask_t m_taskBuffer{};
 
 public:
+  static constexpr bool is_static = true;
+
   static_task_allocator() = default;
   ~static_task_allocator() = default;
   static_task_allocator(const static_task_allocator &) = delete;
@@ -95,6 +97,8 @@ public:
  */
 template <size_t StackSize> class dynamic_task_allocator {
 public:
+  static constexpr bool is_static = false;
+
   void swap(dynamic_task_allocator &other) noexcept { (void)other; }
 
   TaskHandle_t create(TaskFunction_t taskFunction, const char *name,
@@ -284,6 +288,7 @@ public:
         m_joinHandle(other.m_joinHandle)
 #endif
   {
+    configASSERT(!TaskAllocator::is_static);
     other.m_hTask = nullptr;
 #if configUSE_TASK_NOTIFICATIONS
     other.m_joinHandle = nullptr;
@@ -304,6 +309,7 @@ public:
 
   task &operator=(const task &) = delete;
   task &operator=(task &&other) noexcept {
+    configASSERT(!TaskAllocator::is_static);
 #if INCLUDE_vTaskDelete
     if (m_hTask) {
       vTaskDelete(m_hTask);
@@ -315,6 +321,7 @@ public:
   }
 
   void swap(task &other) noexcept {
+    configASSERT(!TaskAllocator::is_static);
     using std::swap;
     m_allocator.swap(other.m_allocator);
     swap(m_hTask, other.m_hTask);

--- a/include/freertos_thread_safety.hpp
+++ b/include/freertos_thread_safety.hpp
@@ -2,7 +2,7 @@
 @file freertos_thread_safety.hpp
 @author Andrey V. Shchekin <aschokin@gmail.com>
 @brief Thread safety annotation macros for FreeRTOS C++ Wrappers
-@version 3.0.0
+@version 3.2.0
 @date 2026-04-17
 
 The MIT License (MIT)

--- a/src/freertos_atomic_wait.cc
+++ b/src/freertos_atomic_wait.cc
@@ -40,7 +40,8 @@ freertos_wait_entry freertos_wait_table[atomic_wait_table_size] = {};
 
 static SemaphoreHandle_t atomic_wait_ensure_semaphore(freertos_wait_entry &entry) {
     if (entry.semaphore == nullptr) {
-        entry.semaphore = xSemaphoreCreateCounting(SemaphoreHandle_t(-1), 0);
+        static constexpr UBaseType_t unbounded_max_count = static_cast<UBaseType_t>(-1);
+        entry.semaphore = xSemaphoreCreateCounting(unbounded_max_count, 0);
         configASSERT(entry.semaphore != nullptr);
     }
     return entry.semaphore;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -377,6 +377,11 @@ add_executable(
 )
 
 add_executable(
+    test_freertos_coverage_exception_safety
+    test_freertos_coverage_exception_safety.cpp
+)
+
+add_executable(
     test_freertos_stream_buffer_callbacks
     test_freertos_stream_buffer_callbacks.cpp
 )
@@ -995,6 +1000,14 @@ target_link_libraries(
 )
 
 target_link_libraries(
+    test_freertos_coverage_exception_safety
+    freertos_cpp_wrappers
+    freertos_mocks
+    ${GTEST_LIBRARIES}
+    pthread
+)
+
+target_link_libraries(
     test_freertos_coverage_branches4
     freertos_cpp_wrappers
     freertos_mocks
@@ -1193,6 +1206,7 @@ target_compile_options(test_freertos_isr_result PRIVATE ${GTEST_COMPILE_OPTIONS}
     target_compile_options(test_freertos_coverage_timer2 PRIVATE ${GTEST_COMPILE_OPTIONS})
     target_compile_options(test_freertos_coverage_expected3 PRIVATE ${GTEST_COMPILE_OPTIONS})
     target_compile_options(test_freertos_coverage_branches4 PRIVATE ${GTEST_COMPILE_OPTIONS})
+    target_compile_options(test_freertos_coverage_exception_safety PRIVATE ${GTEST_COMPILE_OPTIONS})
     target_compile_options(test_freertos_stream_buffer_callbacks PRIVATE ${GTEST_COMPILE_OPTIONS})
     target_compile_options(test_freertos_stream_batching_buffer PRIVATE ${GTEST_COMPILE_OPTIONS})
     target_compile_options(test_freertos_task_join PRIVATE ${GTEST_COMPILE_OPTIONS})
@@ -1282,6 +1296,7 @@ add_test(NAME test_freertos_coverage_expected2 COMMAND test_freertos_coverage_ex
 add_test(NAME test_freertos_coverage_timer2 COMMAND test_freertos_coverage_timer2)
 add_test(NAME test_freertos_coverage_expected3 COMMAND test_freertos_coverage_expected3)
 add_test(NAME test_freertos_coverage_branches4 COMMAND test_freertos_coverage_branches4)
+add_test(NAME test_freertos_coverage_exception_safety COMMAND test_freertos_coverage_exception_safety)
 
 add_test(NAME test_freertos_stream_buffer_callbacks COMMAND test_freertos_stream_buffer_callbacks)
 add_test(NAME test_freertos_task_join COMMAND test_freertos_task_join)

--- a/tests/test_freertos_atomic.cpp
+++ b/tests/test_freertos_atomic.cpp
@@ -98,6 +98,8 @@ TEST_F(AtomicFlagTest, NotifyAllCreatesSemaphore) {
   freertos::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, uxSemaphoreGetCount(mock_semaphore_handle))
+      .WillOnce(Return(0));
   EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
       .Times(FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
       .WillRepeatedly(Return(pdTRUE));
@@ -108,28 +110,55 @@ TEST_F(AtomicFlagTest, NotifyAllCreatesSemaphore) {
 TEST_F(AtomicFlagTest, WaitReturnsImmediatelyWhenDifferent) {
   freertos::atomic_flag f;
   f.test_and_set();
-  f.wait(false);
+  auto result = f.wait(false);
+  EXPECT_TRUE(result.has_value());
 }
 
-TEST_F(AtomicFlagTest, NotifyOneIsr) {
+TEST_F(AtomicFlagTest, NotifyOneIsrWithoutSemaphore) {
+  freertos::atomic_flag f;
+  auto result = f.notify_one_isr();
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+}
+
+TEST_F(AtomicFlagTest, NotifyOneIsrWithSemaphore) {
   freertos::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_semaphore_handle));
+  f.notify_one();
+
   EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_semaphore_handle, _))
       .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_semaphore_handle));
   auto result = f.notify_one_isr();
   EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
 }
 
-TEST_F(AtomicFlagTest, NotifyAllIsr) {
+TEST_F(AtomicFlagTest, NotifyAllIsrWithoutSemaphore) {
+  freertos::atomic_flag f;
+  auto result = f.notify_all_isr();
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+}
+
+TEST_F(AtomicFlagTest, NotifyAllIsrWithSemaphore) {
   freertos::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, uxSemaphoreGetCount(mock_semaphore_handle))
+      .WillOnce(Return(0));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
+      .Times(FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_semaphore_handle));
+  f.notify_all();
+
+  EXPECT_CALL(*mock, uxQueueMessagesWaitingFromISR(
+      reinterpret_cast<QueueHandle_t>(mock_semaphore_handle)))
+      .WillOnce(Return(0));
   EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_semaphore_handle, _))
       .Times(FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
       .WillRepeatedly(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_semaphore_handle));
   auto result = f.notify_all_isr();
   EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
 }
@@ -161,6 +190,8 @@ TEST_F(AtomicFlagTest, NotifyAllExSuccess) {
   freertos::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, uxSemaphoreGetCount(mock_semaphore_handle))
+      .WillOnce(Return(0));
   EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
       .Times(FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
       .WillRepeatedly(Return(pdTRUE));
@@ -173,6 +204,8 @@ TEST_F(AtomicFlagTest, NotifyAllExPartialFailure) {
   freertos::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, uxSemaphoreGetCount(mock_semaphore_handle))
+      .WillOnce(Return(0));
   EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
       .Times(FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
       .WillRepeatedly(Return(pdTRUE));
@@ -185,6 +218,8 @@ TEST_F(AtomicFlagTest, SemaphoreCreatedOnlyOnce) {
   freertos::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, uxSemaphoreGetCount(mock_semaphore_handle))
+      .WillOnce(Return(0));
   EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
       .Times(1 + FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
       .WillRepeatedly(Return(pdTRUE));
@@ -432,13 +467,23 @@ TEST_F(StaticAtomicFlagTest, NotifyOneCreatesSemaphore) {
   f.notify_one();
 }
 
-TEST_F(StaticAtomicFlagTest, NotifyOneIsr) {
+TEST_F(StaticAtomicFlagTest, NotifyOneIsrWithoutSemaphore) {
+  freertos::sa::atomic_flag f;
+  auto result = f.notify_one_isr();
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+}
+
+TEST_F(StaticAtomicFlagTest, NotifyOneIsrWithSemaphore) {
   freertos::sa::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_semaphore_handle));
+  f.notify_one();
+
   EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_semaphore_handle, _))
       .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_semaphore_handle));
   auto result = f.notify_one_isr();
   EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
 }
@@ -446,13 +491,16 @@ TEST_F(StaticAtomicFlagTest, NotifyOneIsr) {
 TEST_F(StaticAtomicFlagTest, WaitReturnsImmediatelyWhenDifferent) {
   freertos::sa::atomic_flag f;
   f.test_and_set();
-  f.wait(false);
+  auto result = f.wait(false);
+  EXPECT_TRUE(result.has_value());
 }
 
 TEST_F(StaticAtomicFlagTest, SemaphoreCreatedOnlyOnce) {
   freertos::sa::atomic_flag f;
   EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, _))
       .WillOnce(Return(mock_semaphore_handle));
+  EXPECT_CALL(*mock, uxSemaphoreGetCount(mock_semaphore_handle))
+      .WillOnce(Return(0));
   EXPECT_CALL(*mock, xSemaphoreGive(mock_semaphore_handle))
       .Times(1 + FREERTOS_CPP_WRAPPERS_ATOMIC_FLAG_MAX_WAITERS)
       .WillRepeatedly(Return(pdTRUE));

--- a/tests/test_freertos_concurrency.cpp
+++ b/tests/test_freertos_concurrency.cpp
@@ -248,41 +248,34 @@ TEST_F(ConcurrencyTest, IsrContextFlagSimulatesInterrupt) {
   EXPECT_EQ(xPortIsInsideInterrupt(), pdFALSE);
 }
 
-TEST_F(ConcurrencyTest, MutexLockIsrCalledInSimulatedIsrContext) {
+TEST_F(ConcurrencyTest, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   mutex_t m;
   g_is_isr_context = true;
   auto lock_result = m.lock_isr();
-  EXPECT_EQ(lock_result.result, pdTRUE);
-  EXPECT_EQ(lock_result.higher_priority_task_woken, pdTRUE);
+  EXPECT_EQ(lock_result.result, pdFALSE);
+  EXPECT_EQ(lock_result.higher_priority_task_woken, pdFALSE);
   auto unlock_result = m.unlock_isr();
-  EXPECT_EQ(unlock_result.result, pdTRUE);
+  EXPECT_EQ(unlock_result.result, pdFALSE);
+  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdFALSE);
   g_is_isr_context = false;
 }
 
-TEST_F(ConcurrencyTest, MutexUnlockIsrPropagatesContextSwitchNeeded) {
+TEST_F(ConcurrencyTest, MutexUnlockIsrReturnsFailureNoContextSwitch) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   mutex_t m;
   auto lock_result = m.lock_isr();
-  EXPECT_EQ(lock_result.result, pdTRUE);
+  EXPECT_EQ(lock_result.result, pdFALSE);
 
   auto unlock_result = m.unlock_isr();
-  EXPECT_EQ(unlock_result.result, pdTRUE);
-  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdTRUE);
+  EXPECT_EQ(unlock_result.result, pdFALSE);
+  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(ConcurrencyTest, BinarySemaphoreGiveIsrReturnsContextSwitchNeeded) {
@@ -331,32 +324,22 @@ TEST_F(ConcurrencyTest, CountingSemaphoreGiveIsrReturnsContextSwitchNeeded) {
 // lock_guard_isr with real freertos::mutex
 // =============================================================================
 
-TEST_F(ConcurrencyTest, LockGuardIsrWithRealMutexAcquiresAndReleases) {
+TEST_F(ConcurrencyTest, LockGuardIsrWithRealMutexFailsToAcquire) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   mutex_t m;
   {
     freertos::lock_guard_isr<mutex_t> guard(m);
-    EXPECT_EQ(guard.high_priority_task_woken(), pdTRUE);
-    EXPECT_TRUE(guard.locked());
+    EXPECT_EQ(guard.high_priority_task_woken(), pdFALSE);
+    EXPECT_FALSE(guard.locked());
   }
 }
 
-TEST_F(ConcurrencyTest, LockGuardIsrContextSwitchPropagatedThroughDestruction) {
+TEST_F(ConcurrencyTest, LockGuardIsrNoContextSwitch) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   mutex_t m;
@@ -482,53 +465,38 @@ TEST_F(ConcurrencyTest, TaskContextUsesNormalApi) {
   EXPECT_EQ(m.unlock(), pdTRUE);
 }
 
-TEST_F(ConcurrencyTest, IsrContextUsesIsrApi) {
+TEST_F(ConcurrencyTest, IsrContextMutexIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   mutex_t m;
   g_is_isr_context = true;
 
   auto lock_result = m.lock_isr();
-  EXPECT_EQ(lock_result.result, pdTRUE);
+  EXPECT_EQ(lock_result.result, pdFALSE);
   EXPECT_EQ(lock_result.higher_priority_task_woken, pdFALSE);
 
   auto unlock_result = m.unlock_isr();
-  EXPECT_EQ(unlock_result.result, pdTRUE);
-  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdTRUE);
+  EXPECT_EQ(unlock_result.result, pdFALSE);
+  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdFALSE);
 
   g_is_isr_context = false;
 }
 
-TEST_F(ConcurrencyTest, PortYieldFromIsrCalledWhenHigherPriorityWoken) {
+TEST_F(ConcurrencyTest, PortYieldFromIsrNotCalledWhenIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, portYIELD_FROM_ISR(pdTRUE)).Times(2);
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   mutex_t m;
   g_is_isr_context = true;
 
   auto lock_result = m.lock_isr();
-  EXPECT_EQ(lock_result.higher_priority_task_woken, pdTRUE);
-  if (lock_result.higher_priority_task_woken) {
-    g_freertos_mock->portYIELD_FROM_ISR(lock_result.higher_priority_task_woken);
-  }
+  EXPECT_EQ(lock_result.higher_priority_task_woken, pdFALSE);
 
   auto unlock_result = m.unlock_isr();
-  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdTRUE);
-  if (unlock_result.higher_priority_task_woken) {
-    g_freertos_mock->portYIELD_FROM_ISR(unlock_result.higher_priority_task_woken);
-  }
+  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdFALSE);
 
   g_is_isr_context = false;
 }

--- a/tests/test_freertos_condition_variable.cpp
+++ b/tests/test_freertos_condition_variable.cpp
@@ -276,7 +276,7 @@ TEST_F(ConditionVariableMockTest, NotifyOneEx_SemaphoreNotOwned) {
     freertos::condition_variable_any cv;
     auto result = cv.notify_one_ex();
     EXPECT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), freertos::error::semaphore_not_owned);
+    EXPECT_EQ(result.error(), freertos::error::would_block);
 }
 
 TEST_F(ConditionVariableMockTest, NotifyAllEx_Success) {
@@ -284,10 +284,10 @@ TEST_F(ConditionVariableMockTest, NotifyAllEx_Success) {
 
     EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(_, _, NotNull()))
         .WillOnce(Return(sem_handle));
-    // notify_all_ex calls notify_all() which gives FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS times
+    // notify_all_ex calls notify_all() — when no waiters are present,
+    // it returns early with zero semaphore gives.
     EXPECT_CALL(*mock, xSemaphoreGive(sem_handle))
-        .Times(FREERTOS_CPP_WRAPPERS_CONDITION_VARIABLE_MAX_WAITERS)
-        .WillRepeatedly(Return(pdTRUE));
+        .Times(0);
     EXPECT_CALL(*mock, vSemaphoreDelete(sem_handle));
 
     freertos::condition_variable_any cv;

--- a/tests/test_freertos_coverage_branches.cpp
+++ b/tests/test_freertos_coverage_branches.cpp
@@ -319,52 +319,26 @@ TEST_F(SemaphoreBranchTest, MutexTryLockExFailure) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(SemaphoreBranchTest, MutexLockExIsrSuccess) {
+TEST_F(SemaphoreBranchTest, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
-
-  freertos::da::mutex m;
-  auto result = m.lock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-}
-
-TEST_F(SemaphoreBranchTest, MutexLockExIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex m;
   auto result = m.lock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(SemaphoreBranchTest, MutexUnlockExIsrSuccess) {
+TEST_F(SemaphoreBranchTest, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTake(fake_sem, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex m;
-  m.lock(0);
-  auto result = m.unlock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-}
-
-TEST_F(SemaphoreBranchTest, MutexUnlockExIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTake(fake_sem, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
-
-  freertos::da::mutex m;
-  m.lock(0);
   auto result = m.unlock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SemaphoreBranchTest, RecursiveMutexUnlockCountZero) {

--- a/tests/test_freertos_coverage_branches2.cpp
+++ b/tests/test_freertos_coverage_branches2.cpp
@@ -543,56 +543,25 @@ TEST_F(SemaphoreBranchTest, MutexTryLockFailure) {
   EXPECT_FALSE(mtx.locked());
 }
 
-TEST_F(SemaphoreBranchTest, MutexLockIsrSuccess) {
+TEST_F(SemaphoreBranchTest, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
-
-  freertos::da::mutex mtx;
-  auto result = mtx.lock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_TRUE(mtx.locked());
-}
-
-TEST_F(SemaphoreBranchTest, MutexLockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex mtx;
   auto result = mtx.lock_isr();
   EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 
-TEST_F(SemaphoreBranchTest, MutexUnlockIsrSuccess) {
+TEST_F(SemaphoreBranchTest, MutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTake(fake_sem, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex mtx;
-  mtx.lock();
-  auto result = mtx.unlock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_FALSE(mtx.locked());
-}
-
-TEST_F(SemaphoreBranchTest, MutexUnlockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTake(fake_sem, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
-
-  freertos::da::mutex mtx;
-  mtx.lock();
   auto result = mtx.unlock_isr();
   EXPECT_EQ(result.result, pdFALSE);
-  EXPECT_TRUE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SemaphoreBranchTest, MutexSelfMoveAssignment) {
@@ -639,28 +608,26 @@ TEST_F(SemaphoreBranchTest, MutexUnlockExFailure) {
   EXPECT_EQ(result.error(), freertos::error::semaphore_not_owned);
 }
 
-TEST_F(SemaphoreBranchTest, MutexLockExIsrFailure) {
+TEST_F(SemaphoreBranchTest, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex mtx;
   auto result = mtx.lock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(SemaphoreBranchTest, MutexUnlockExIsrFailure) {
+TEST_F(SemaphoreBranchTest, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTake(fake_sem, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex mtx;
-  mtx.lock();
   auto result = mtx.unlock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 // --- recursive_mutex ---

--- a/tests/test_freertos_coverage_ex_variants.cpp
+++ b/tests/test_freertos_coverage_ex_variants.cpp
@@ -205,24 +205,24 @@ TEST_F(ExVariantsSemTest, MutexUnlockExFailure) {
   EXPECT_EQ(r.error(), freertos::error::semaphore_not_owned);
 }
 
-TEST_F(ExVariantsSemTest, MutexLockExIsrFailure) {
+TEST_F(ExVariantsSemTest, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(h));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(h, _)).WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(h));
   freertos::mutex<freertos::dynamic_semaphore_allocator> m;
   auto r = m.lock_ex_isr();
   EXPECT_FALSE(r.result.has_value());
   EXPECT_EQ(r.result.error(), freertos::error::would_block);
+  EXPECT_EQ(r.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(ExVariantsSemTest, MutexUnlockExIsrFailure) {
+TEST_F(ExVariantsSemTest, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(h));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(h, _)).WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(h));
   freertos::mutex<freertos::dynamic_semaphore_allocator> m;
   auto r = m.unlock_ex_isr();
   EXPECT_FALSE(r.result.has_value());
   EXPECT_EQ(r.result.error(), freertos::error::semaphore_not_owned);
+  EXPECT_EQ(r.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(ExVariantsSemTest, MutexTryLockExFailure) {

--- a/tests/test_freertos_coverage_exception_safety.cpp
+++ b/tests/test_freertos_coverage_exception_safety.cpp
@@ -1,0 +1,423 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "FreeRTOS.h"
+#include "freertos_semaphore.hpp"
+#include "freertos_shared_data.hpp"
+#include "freertos_condition_variable.hpp"
+#include "freertos_latch.hpp"
+
+#include <stdexcept>
+#include <chrono>
+#include <mutex>
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::StrictMock;
+
+class ThrowingCopy {
+public:
+  int value = 0;
+  static bool copy_throws;
+  static bool assign_throws;
+  static bool move_assign_throws;
+
+  ThrowingCopy() = default;
+  explicit ThrowingCopy(int v) : value(v) {}
+
+  ThrowingCopy(const ThrowingCopy &other) : value(other.value) {
+    if (copy_throws) {
+      throw std::runtime_error("copy ctor throws");
+    }
+  }
+
+  ThrowingCopy &operator=(const ThrowingCopy &other) {
+    value = other.value;
+    if (assign_throws) {
+      throw std::runtime_error("copy assign throws");
+    }
+    return *this;
+  }
+
+  ThrowingCopy(ThrowingCopy &&other) : value(other.value) {}
+
+  ThrowingCopy &operator=(ThrowingCopy &&other) {
+    value = other.value;
+    if (move_assign_throws) {
+      throw std::runtime_error("move assign throws");
+    }
+    return *this;
+  }
+};
+
+bool ThrowingCopy::copy_throws = false;
+bool ThrowingCopy::assign_throws = false;
+bool ThrowingCopy::move_assign_throws = false;
+
+class ResetThrowingFlags {
+public:
+  ResetThrowingFlags() {
+    ThrowingCopy::copy_throws = false;
+    ThrowingCopy::assign_throws = false;
+    ThrowingCopy::move_assign_throws = false;
+  }
+  ~ResetThrowingFlags() {
+    ThrowingCopy::copy_throws = false;
+    ThrowingCopy::assign_throws = false;
+    ThrowingCopy::move_assign_throws = false;
+  }
+};
+
+// ================================================================
+// SHARED_DATA: exception safety catch blocks
+// ================================================================
+
+class SharedDataExceptionTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    mock = new StrictMock<FreeRTOSMock>();
+    g_freertos_mock = mock;
+    ResetThrowingFlags();
+  }
+  void TearDown() override {
+    delete mock;
+    g_freertos_mock = nullptr;
+    ThrowingCopy::copy_throws = false;
+    ThrowingCopy::assign_throws = false;
+    ThrowingCopy::move_assign_throws = false;
+  }
+  StrictMock<FreeRTOSMock> *mock;
+  SemaphoreHandle_t mock_handle =
+      reinterpret_cast<SemaphoreHandle_t>(0xABCDEFFF);
+};
+
+TEST_F(SharedDataExceptionTest, GetThrowsOnCopy) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<ThrowingCopy> data(ThrowingCopy(42));
+  ThrowingCopy::copy_throws = true;
+  EXPECT_THROW(data.get(), std::runtime_error);
+}
+
+TEST_F(SharedDataExceptionTest, SetThrowsOnAssignment) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<ThrowingCopy> data(ThrowingCopy(10));
+  ThrowingCopy::assign_throws = true;
+  ThrowingCopy val(42);
+  EXPECT_THROW(data.set(val), std::runtime_error);
+}
+
+TEST_F(SharedDataExceptionTest, SetMoveThrowsOnMoveAssignment) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<ThrowingCopy> data(ThrowingCopy(10));
+  ThrowingCopy::move_assign_throws = true;
+  ThrowingCopy val(42);
+  EXPECT_THROW(data.set(std::move(val)), std::runtime_error);
+}
+
+TEST_F(SharedDataExceptionTest, UseLambdaThrows) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<int> data(5);
+  EXPECT_THROW(data.use([](int &) { throw std::runtime_error("test"); }),
+               std::runtime_error);
+}
+
+TEST_F(SharedDataExceptionTest, GetExThrowsOnCopy) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<ThrowingCopy> data(ThrowingCopy(42));
+  ThrowingCopy::copy_throws = true;
+  EXPECT_THROW(data.get_ex(), std::runtime_error);
+}
+
+TEST_F(SharedDataExceptionTest, SetExThrowsOnAssignment) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<ThrowingCopy> data(ThrowingCopy(10));
+  ThrowingCopy::assign_throws = true;
+  ThrowingCopy val(42);
+  EXPECT_THROW(data.set_ex(val), std::runtime_error);
+}
+
+TEST_F(SharedDataExceptionTest, SetExMoveThrowsOnMoveAssignment) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::shared_data<ThrowingCopy> data(ThrowingCopy(10));
+  ThrowingCopy::move_assign_throws = true;
+  ThrowingCopy val(42);
+  EXPECT_THROW(data.set_ex(std::move(val)), std::runtime_error);
+}
+
+// ================================================================
+// MUTEX::CLAIM() catch block
+// ================================================================
+
+class MutexClaimExceptionTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    mock = new StrictMock<FreeRTOSMock>();
+    g_freertos_mock = mock;
+  }
+  void TearDown() override {
+    delete mock;
+    g_freertos_mock = nullptr;
+  }
+  StrictMock<FreeRTOSMock> *mock;
+  SemaphoreHandle_t mock_handle =
+      reinterpret_cast<SemaphoreHandle_t>(0x87654321);
+};
+
+TEST_F(MutexClaimExceptionTest, MutexClaimLambdaThrows) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::da::mutex m;
+  EXPECT_THROW(m.claim([]() { throw std::runtime_error("test"); }),
+               std::runtime_error);
+}
+
+TEST_F(MutexClaimExceptionTest, MutexClaimLambdaThrowsVoidReturn) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::da::mutex m;
+  bool called = false;
+  try {
+    m.claim([&called]() {
+      called = true;
+      throw 42;
+    });
+  } catch (int) {
+  }
+  EXPECT_TRUE(called);
+}
+
+TEST_F(MutexClaimExceptionTest, RecursiveMutexClaimLambdaThrows) {
+  EXPECT_CALL(*mock, xSemaphoreCreateRecursiveMutex())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTakeRecursive(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGiveRecursive(mock_handle))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::da::recursive_mutex rm;
+  EXPECT_THROW(rm.claim([]() { throw std::runtime_error("test"); }),
+               std::runtime_error);
+}
+
+TEST_F(MutexClaimExceptionTest, RecursiveMutexClaimLambdaThrowsVoidReturn) {
+  EXPECT_CALL(*mock, xSemaphoreCreateRecursiveMutex())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTakeRecursive(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGiveRecursive(mock_handle))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::da::recursive_mutex rm;
+  bool called = false;
+  try {
+    rm.claim([&called]() {
+      called = true;
+      throw 42;
+    });
+  } catch (int) {
+  }
+  EXPECT_TRUE(called);
+}
+
+TEST_F(MutexClaimExceptionTest, MutexWithLockLambdaThrows) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTake(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::da::mutex m;
+  EXPECT_THROW(m.with_lock([]() { throw std::runtime_error("test"); }),
+               std::runtime_error);
+}
+
+TEST_F(MutexClaimExceptionTest, RecursiveMutexWithLockLambdaThrows) {
+  EXPECT_CALL(*mock, xSemaphoreCreateRecursiveMutex())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreTakeRecursive(mock_handle, portMAX_DELAY))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGiveRecursive(mock_handle))
+      .WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::da::recursive_mutex rm;
+  EXPECT_THROW(rm.with_lock([]() { throw std::runtime_error("test"); }),
+               std::runtime_error);
+}
+
+// ================================================================
+// CONDITION_VARIABLE: wait_until with past deadline
+// These tests use std::mutex since they test the condition_variable_any
+// with a non-FreeRTOS lock, but we need the FreeRTOS mock for the
+// condition_variable's semaphore.
+// ================================================================
+
+TEST(ConditionVariablePastDeadline, WaitUntilPastDeadlineReturnsTimeout) {
+  freertos::condition_variable_any cv;
+  std::mutex m;
+  m.lock();
+  auto past = std::chrono::steady_clock::now() - std::chrono::hours(1);
+  auto status = cv.wait_until(m, past);
+  EXPECT_EQ(status, std::cv_status::timeout);
+}
+
+TEST(ConditionVariablePastDeadline, WaitUntilPredicatePastDeadlineTrue) {
+  freertos::condition_variable_any cv;
+  std::mutex m;
+  m.lock();
+  auto past = std::chrono::steady_clock::now() - std::chrono::hours(1);
+  bool result = cv.wait_until(m, past, [] { return true; });
+  EXPECT_TRUE(result);
+}
+
+TEST(ConditionVariablePastDeadline, WaitUntilPredicatePastDeadlineFalse) {
+  freertos::condition_variable_any cv;
+  std::mutex m;
+  m.lock();
+  auto past = std::chrono::steady_clock::now() - std::chrono::hours(1);
+  bool result = cv.wait_until(m, past, [] { return false; });
+  EXPECT_FALSE(result);
+}
+
+// ================================================================
+// LATCH: edge cases for uncovered branches
+// ================================================================
+
+class LatchBranchTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    mock = new StrictMock<FreeRTOSMock>();
+    g_freertos_mock = mock;
+  }
+  void TearDown() override {
+    delete mock;
+    g_freertos_mock = nullptr;
+  }
+  StrictMock<FreeRTOSMock> *mock;
+  SemaphoreHandle_t mock_handle =
+      reinterpret_cast<SemaphoreHandle_t>(0x11111111);
+};
+
+TEST_F(LatchBranchTest, CountDownAlreadyZeroNoGive) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(1);
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  l.count_down(1);
+  EXPECT_TRUE(l.try_wait());
+
+  l.count_down(1);
+  EXPECT_TRUE(l.try_wait());
+}
+
+TEST_F(LatchBranchTest, CountDownExAlreadyZero) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(1);
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  l.count_down(1);
+
+  auto result = l.count_down_ex(1);
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(LatchBranchTest, CountDownNegativeUpdate) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(3);
+  l.count_down(-1);
+  EXPECT_FALSE(l.try_wait());
+}
+
+TEST_F(LatchBranchTest, CountDownExNegativeUpdate) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(3);
+  auto result = l.count_down_ex(-1);
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(LatchBranchTest, CountDownIsrNegativeUpdate) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(3);
+  auto result = l.count_down_isr(-1);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+}
+
+TEST_F(LatchBranchTest, CountDownExIsrNegativeUpdate) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(3);
+  auto result = l.count_down_ex_isr(-1);
+  EXPECT_TRUE(result.result.has_value());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+}
+
+TEST_F(LatchBranchTest, CountDownByMoreThanRemainingClampsToZero) {
+  EXPECT_CALL(*mock, xSemaphoreCreateBinary())
+      .WillOnce(Return(mock_handle));
+  EXPECT_CALL(*mock, xSemaphoreGive(mock_handle)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_handle));
+
+  freertos::latch l(2);
+  l.count_down(5);
+  EXPECT_TRUE(l.try_wait());
+}

--- a/tests/test_freertos_coverage_faults.cpp
+++ b/tests/test_freertos_coverage_faults.cpp
@@ -376,14 +376,14 @@ TEST_F(SemaphoreFaultTest, MutexLockExTimeout) {
   EXPECT_EQ(result.error(), freertos::error::timeout);
 }
 
-TEST_F(SemaphoreFaultTest, MutexLockExIsrSuccess) {
+TEST_F(SemaphoreFaultTest, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
   auto result = m.lock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
+  EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SemaphoreFaultTest, MutexUnlockExSuccess) {
@@ -398,17 +398,14 @@ TEST_F(SemaphoreFaultTest, MutexUnlockExSuccess) {
   EXPECT_TRUE(result.has_value());
 }
 
-TEST_F(SemaphoreFaultTest, MutexUnlockExIsrSuccess) {
+TEST_F(SemaphoreFaultTest, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
-  m.lock_isr();
   auto result = m.unlock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
+  EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SemaphoreFaultTest, MutexTryLockExSuccess) {
@@ -1653,10 +1650,6 @@ TEST_F(SemArgCtorTest, MutexTryLockUntilFuturePath) {
 
 TEST_F(SemArgCtorTest, LockGuardIsrConstructorFailurePath) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
   freertos::lock_guard_isr<freertos::da::mutex> guard(m);
@@ -2495,40 +2488,42 @@ TEST_F(SemChronoTest, CountingSemaphoreTakeExIsrThrows) {
   EXPECT_THROW((void)cs.take_ex_isr(), std::runtime_error);
 }
 
-TEST_F(SemChronoTest, MutexLockIsrThrows) {
+TEST_F(SemChronoTest, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(Throw(std::runtime_error("boom")));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
-  EXPECT_THROW((void)m.lock_isr(), std::runtime_error);
+  auto result = m.lock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(SemChronoTest, MutexUnlockIsrThrows) {
+TEST_F(SemChronoTest, MutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(Throw(std::runtime_error("boom")));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
-  EXPECT_THROW((void)m.unlock_isr(), std::runtime_error);
+  auto result = m.unlock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(SemChronoTest, MutexLockExIsrThrows) {
+TEST_F(SemChronoTest, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(Throw(std::runtime_error("boom")));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
-  EXPECT_THROW((void)m.lock_ex_isr(), std::runtime_error);
+  auto result = m.lock_ex_isr();
+  EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(SemChronoTest, MutexUnlockExIsrThrows) {
+TEST_F(SemChronoTest, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(Throw(std::runtime_error("boom")));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::da::mutex m;
-  EXPECT_THROW((void)m.unlock_ex_isr(), std::runtime_error);
+  auto result = m.unlock_ex_isr();
+  EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SemChronoTest, RecursiveMutexTryLockUntilExpiredFalse) {
@@ -3819,16 +3814,12 @@ TEST_F(SemaphoreCoverageTest, TryLockGuardLockedFalseWhenNotAcquired) {
 TEST_F(SemaphoreCoverageTest, LockGuardIsrConstructorAndDestructor) {
   testing::InSequence seq;
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
 
   freertos::da::mutex m;
   {
     freertos::lock_guard_isr<freertos::da::mutex> guard(m);
-    EXPECT_TRUE(guard.locked());
+    EXPECT_FALSE(guard.locked());
   }
 }
 

--- a/tests/test_freertos_coverage_isr.cpp
+++ b/tests/test_freertos_coverage_isr.cpp
@@ -110,40 +110,22 @@ protected:
   }
 };
 
-TEST_F(IsrMutexTest, LockIsrSuccess) {
+TEST_F(IsrMutexTest, LockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(h));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(h, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, vSemaphoreDelete(h));
-  freertos::mutex<freertos::dynamic_semaphore_allocator> m;
-  auto r = m.lock_isr();
-  EXPECT_EQ(r.result, pdTRUE);
-}
-
-TEST_F(IsrMutexTest, LockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(h));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(h, _)).WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(h));
   freertos::mutex<freertos::dynamic_semaphore_allocator> m;
   auto r = m.lock_isr();
   EXPECT_EQ(r.result, pdFALSE);
+  EXPECT_EQ(r.higher_priority_task_woken, pdFALSE);
 }
 
-TEST_F(IsrMutexTest, UnlockIsrSuccess) {
+TEST_F(IsrMutexTest, UnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(h));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(h, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, vSemaphoreDelete(h));
-  freertos::mutex<freertos::dynamic_semaphore_allocator> m;
-  auto r = m.unlock_isr();
-  EXPECT_EQ(r.result, pdTRUE);
-}
-
-TEST_F(IsrMutexTest, UnlockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(h));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(h, _)).WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(h));
   freertos::mutex<freertos::dynamic_semaphore_allocator> m;
   auto r = m.unlock_isr();
   EXPECT_EQ(r.result, pdFALSE);
+  EXPECT_EQ(r.higher_priority_task_woken, pdFALSE);
 }
 
 class IsrQueueTest : public ::testing::Test {

--- a/tests/test_freertos_coverage_sa_ns.cpp
+++ b/tests/test_freertos_coverage_sa_ns.cpp
@@ -625,15 +625,14 @@ TEST_F(SaMutexTest, LockExWouldBlock) {
   EXPECT_EQ(result.error(), freertos::error::would_block);
 }
 
-TEST_F(SaMutexTest, LockExIsrFailure) {
-  BaseType_t high_task_woken = pdFALSE;
+TEST_F(SaMutexTest, LockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_)).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _))
-      .WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::sa::mutex m;
   auto result = m.lock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SaMutexTest, UnlockExFailure) {
@@ -645,15 +644,14 @@ TEST_F(SaMutexTest, UnlockExFailure) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(SaMutexTest, UnlockExIsrFailure) {
-  BaseType_t high_task_woken = pdFALSE;
+TEST_F(SaMutexTest, UnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_)).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _))
-      .WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::sa::mutex m;
   auto result = m.unlock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
+  EXPECT_EQ(result.result.error(), freertos::error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(SaMutexTest, TryLockExFailure) {
@@ -858,15 +856,13 @@ TEST_F(GuardBranchTest, TimeoutLockGuardSuccessUnlocks) {
 }
 
 TEST_F(GuardBranchTest, LockGuardIsrOnSaMutex) {
-  BaseType_t high_task_woken = pdFALSE;
   testing::InSequence seq;
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_)).WillOnce(Return(fake_sem));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(fake_sem, _)).WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(fake_sem, _)).WillOnce(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(fake_sem));
   freertos::sa::mutex m;
   {
     freertos::lock_guard_isr<freertos::sa::mutex> guard(m);
+    EXPECT_FALSE(guard.locked());
   }
 }
 

--- a/tests/test_freertos_coverage_semaphores.cpp
+++ b/tests/test_freertos_coverage_semaphores.cpp
@@ -333,57 +333,23 @@ TEST_F(CoverageSemaphoreTest, MutexLockExChrono) {
   EXPECT_TRUE(mtx.locked());
 }
 
-TEST_F(CoverageSemaphoreTest, MutexLockIsrSuccess) {
+TEST_F(CoverageSemaphoreTest, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  auto result = mtx.lock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_TRUE(mtx.locked());
-}
-
-TEST_F(CoverageSemaphoreTest, MutexLockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   auto result = mtx.lock_isr();
   EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 
-TEST_F(CoverageSemaphoreTest, MutexUnlockIsrSuccess) {
+TEST_F(CoverageSemaphoreTest, MutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
-  auto result = mtx.unlock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
-  EXPECT_FALSE(mtx.locked());
-}
-
-TEST_F(CoverageSemaphoreTest, MutexUnlockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
   auto result = mtx.unlock_isr();
   EXPECT_EQ(result.result, pdFALSE);
-  EXPECT_TRUE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(CoverageSemaphoreTest, MutexTryLockFor) {
@@ -492,18 +458,14 @@ TEST_F(CoverageSemaphoreTest, RecursiveMutexTryLockUntilFutureTime) {
   EXPECT_TRUE(rm.try_lock_until(future));
 }
 
-TEST_F(CoverageSemaphoreTest, LockGuardIsrWithMutex) {
+TEST_F(CoverageSemaphoreTest, LockGuardIsrWithMutexFails) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   {
     freertos::lock_guard_isr<Mutex> guard(mtx);
-    EXPECT_TRUE(guard.locked());
-    EXPECT_EQ(guard.high_priority_task_woken(), pdTRUE);
+    EXPECT_FALSE(guard.locked());
+    EXPECT_EQ(guard.high_priority_task_woken(), pdFALSE);
   }
   EXPECT_FALSE(mtx.locked());
 }

--- a/tests/test_freertos_coverage_semaphores2.cpp
+++ b/tests/test_freertos_coverage_semaphores2.cpp
@@ -254,22 +254,8 @@ TEST_F(CoverageSemaphore2Test, MutexLockExWouldBlock) {
   EXPECT_FALSE(mtx.locked());
 }
 
-TEST_F(CoverageSemaphore2Test, MutexLockExIsrSuccess) {
+TEST_F(CoverageSemaphore2Test, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  auto result = mtx.lock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-  EXPECT_TRUE(mtx.locked());
-  EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
-}
-
-TEST_F(CoverageSemaphore2Test, MutexLockExIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   auto result = mtx.lock_ex_isr();
@@ -289,36 +275,14 @@ TEST_F(CoverageSemaphore2Test, MutexUnlockExFailure) {
   EXPECT_EQ(result.error(), error::semaphore_not_owned);
 }
 
-TEST_F(CoverageSemaphore2Test, MutexUnlockExIsrSuccess) {
+TEST_F(CoverageSemaphore2Test, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
-  auto result = mtx.unlock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-  EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
-  EXPECT_FALSE(mtx.locked());
-}
-
-TEST_F(CoverageSemaphore2Test, MutexUnlockExIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
   auto result = mtx.unlock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
   EXPECT_EQ(result.result.error(), error::semaphore_not_owned);
-  EXPECT_TRUE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(CoverageSemaphore2Test, MutexTryLockExFailure) {
@@ -331,30 +295,23 @@ TEST_F(CoverageSemaphore2Test, MutexTryLockExFailure) {
   EXPECT_EQ(result.error(), error::would_block);
 }
 
-TEST_F(CoverageSemaphore2Test, MutexLockIsrFailureNoMutedState) {
+TEST_F(CoverageSemaphore2Test, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   auto result = mtx.lock_isr();
   EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 
-TEST_F(CoverageSemaphore2Test, MutexUnlockIsrFailureNoStateChange) {
+TEST_F(CoverageSemaphore2Test, MutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
   auto result = mtx.unlock_isr();
   EXPECT_EQ(result.result, pdFALSE);
-  EXPECT_TRUE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(CoverageSemaphore2Test, MutexSwapWithLockedState) {
@@ -437,28 +394,8 @@ TEST_F(CoverageSemaphore2Test, RecursiveMutexSwapWithRecursionCount) {
 // Guard classes
 // ============================================================
 
-TEST_F(CoverageSemaphore2Test, LockGuardIsrConstructorDestructor) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  {
-    freertos::lock_guard_isr<Mutex> guard(mtx);
-    EXPECT_TRUE(guard.locked());
-    EXPECT_EQ(guard.high_priority_task_woken(), pdTRUE);
-  }
-  EXPECT_FALSE(mtx.locked());
-}
-
 TEST_F(CoverageSemaphore2Test, LockGuardIsrLockFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   {

--- a/tests/test_freertos_coverage_semaphores3.cpp
+++ b/tests/test_freertos_coverage_semaphores3.cpp
@@ -467,29 +467,13 @@ TEST_F(CoverageSemaphore3Test, MutexSwapBothLocked) {
 // Lines 687-694
 // ============================================================
 
-TEST_F(CoverageSemaphore3Test, MutexUnlockIsrSuccess) {
+TEST_F(CoverageSemaphore3Test, MutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
-  auto result = mtx.unlock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_FALSE(mtx.locked());
-}
-
-TEST_F(CoverageSemaphore3Test, MutexUnlockIsrFailureNoState) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   auto result = mtx.unlock_isr();
   EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 
@@ -498,16 +482,14 @@ TEST_F(CoverageSemaphore3Test, MutexUnlockIsrFailureNoState) {
 // Lines 718-725
 // ============================================================
 
-TEST_F(CoverageSemaphore3Test, MutexLockIsrSuccess) {
+TEST_F(CoverageSemaphore3Test, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   auto result = mtx.lock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_TRUE(mtx.locked());
-  EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+  EXPECT_FALSE(mtx.locked());
 }
 
 // ============================================================
@@ -525,25 +507,14 @@ TEST_F(CoverageSemaphore3Test, MutexLockExWouldBlock) {
   EXPECT_EQ(result.error(), error::would_block);
 }
 
-TEST_F(CoverageSemaphore3Test, MutexLockExIsrSuccess2) {
+TEST_F(CoverageSemaphore3Test, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  auto result = mtx.lock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-}
-
-TEST_F(CoverageSemaphore3Test, MutexLockExIsrFailure2) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   auto result = mtx.lock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
   EXPECT_EQ(result.result.error(), error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(CoverageSemaphore3Test, MutexUnlockExFailure2) {
@@ -556,31 +527,14 @@ TEST_F(CoverageSemaphore3Test, MutexUnlockExFailure2) {
   EXPECT_EQ(result.error(), error::semaphore_not_owned);
 }
 
-TEST_F(CoverageSemaphore3Test, MutexUnlockExIsrSuccess2) {
+TEST_F(CoverageSemaphore3Test, MutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
-  mtx.lock();
-  auto result = mtx.unlock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-}
-
-TEST_F(CoverageSemaphore3Test, MutexUnlockExIsrFailure2) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  Mutex mtx;
-  mtx.lock();
   auto result = mtx.unlock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
   EXPECT_EQ(result.result.error(), error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(CoverageSemaphore3Test, MutexTryLockExFailure2) {
@@ -859,25 +813,17 @@ TEST_F(CoverageSemaphore3Test, TryLockGuardLockedMethodFail) {
 
 TEST_F(CoverageSemaphore3Test, LockGuardIsrFullCycle) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   {
     freertos::lock_guard_isr<Mutex> guard(mtx);
-    EXPECT_TRUE(guard.locked());
-    EXPECT_EQ(guard.high_priority_task_woken(), pdTRUE);
+    EXPECT_FALSE(guard.locked());
+    EXPECT_EQ(guard.high_priority_task_woken(), pdFALSE);
   }
 }
 
 TEST_F(CoverageSemaphore3Test, LockGuardIsrFailCycle) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex()).WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   Mutex mtx;
   {

--- a/tests/test_freertos_coverage_semaphores4.cpp
+++ b/tests/test_freertos_coverage_semaphores4.cpp
@@ -577,61 +577,25 @@ TEST_F(CoverageSemaphore4Test, SaMutexSwapWithLockedState) {
 // mutex (static allocator) — lock_isr / unlock_isr success and failure
 // ============================================================
 
-TEST_F(CoverageSemaphore4Test, SaMutexLockIsrSuccess) {
+TEST_F(CoverageSemaphore4Test, SaMutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
       .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  MutexSA mtx;
-  auto result = mtx.lock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_TRUE(mtx.locked());
-  EXPECT_EQ(result.higher_priority_task_woken, pdTRUE);
-}
-
-TEST_F(CoverageSemaphore4Test, SaMutexLockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
-      .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   MutexSA mtx;
   auto result = mtx.lock_isr();
   EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 
-TEST_F(CoverageSemaphore4Test, SaMutexUnlockIsrSuccess) {
+TEST_F(CoverageSemaphore4Test, SaMutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
       .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   MutexSA mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
-  auto result = mtx.unlock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_FALSE(mtx.locked());
-}
-
-TEST_F(CoverageSemaphore4Test, SaMutexUnlockIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
-      .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  MutexSA mtx;
-  mtx.lock();
-  EXPECT_TRUE(mtx.locked());
   auto result = mtx.unlock_isr();
   EXPECT_EQ(result.result, pdFALSE);
-  EXPECT_TRUE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 // ============================================================
@@ -665,29 +629,16 @@ TEST_F(CoverageSemaphore4Test, SaMutexLockExTimeout) {
 // mutex (static allocator) — lock_ex_isr success and failure
 // ============================================================
 
-TEST_F(CoverageSemaphore4Test, SaMutexLockExIsrSuccess) {
+TEST_F(CoverageSemaphore4Test, SaMutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
       .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  MutexSA mtx;
-  auto result = mtx.lock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-  EXPECT_TRUE(mtx.locked());
-}
-
-TEST_F(CoverageSemaphore4Test, SaMutexLockExIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
-      .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   MutexSA mtx;
   auto result = mtx.lock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
   EXPECT_EQ(result.result.error(), error::would_block);
   EXPECT_FALSE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 // ============================================================
@@ -709,33 +660,15 @@ TEST_F(CoverageSemaphore4Test, SaMutexUnlockExFailure) {
 // mutex (static allocator) — unlock_ex_isr success and failure
 // ============================================================
 
-TEST_F(CoverageSemaphore4Test, SaMutexUnlockExIsrSuccess) {
+TEST_F(CoverageSemaphore4Test, SaMutexUnlockExIsrReturnsNotOwned) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
       .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   MutexSA mtx;
-  mtx.lock();
-  auto result = mtx.unlock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-}
-
-TEST_F(CoverageSemaphore4Test, SaMutexUnlockExIsrFailure) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
-      .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  MutexSA mtx;
-  mtx.lock();
   auto result = mtx.unlock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
   EXPECT_EQ(result.result.error(), error::semaphore_not_owned);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 // ============================================================
@@ -936,29 +869,9 @@ TEST_F(CoverageSemaphore4Test, SaMutexTryLockGuardFailure) {
 // Guard classes on static mutex — lock_guard_isr
 // ============================================================
 
-TEST_F(CoverageSemaphore4Test, SaMutexLockGuardIsrSuccess) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
-      .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdTRUE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
-  MutexSA mtx;
-  {
-    freertos::lock_guard_isr<MutexSA> guard(mtx);
-    EXPECT_TRUE(guard.locked());
-    EXPECT_EQ(guard.high_priority_task_woken(), pdTRUE);
-  }
-}
-
 TEST_F(CoverageSemaphore4Test, SaMutexLockGuardIsrFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutexStatic(_))
       .WillOnce(Return(mock_mutex));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex));
   MutexSA mtx;
   {

--- a/tests/test_freertos_expected_api.cpp
+++ b/tests/test_freertos_expected_api.cpp
@@ -214,29 +214,16 @@ TEST_F(ExpectedApiTest, MutexTryLockExWouldBlock) {
   EXPECT_EQ(result.error(), freertos::error::would_block);
 }
 
-TEST_F(ExpectedApiTest, MutexLockExIsrSuccess) {
+TEST_F(ExpectedApiTest, MutexLockExIsrReturnsWouldBlock) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdTRUE)));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
-
-  freertos::da::mutex mtx;
-  auto result = mtx.lock_ex_isr();
-  EXPECT_TRUE(result.result.has_value());
-}
-
-TEST_F(ExpectedApiTest, MutexLockExIsrWouldBlock) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex())
-      .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(DoAll(SetArgPointee<1>(pdFALSE), Return(pdFALSE)));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::da::mutex mtx;
   auto result = mtx.lock_ex_isr();
   EXPECT_FALSE(result.result.has_value());
   EXPECT_EQ(result.result.error(), freertos::error::would_block);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 // ---------- queue _ex ----------

--- a/tests/test_freertos_fixed_function.cpp
+++ b/tests/test_freertos_fixed_function.cpp
@@ -173,10 +173,10 @@ TEST(FixedFunctionTest, MoveOnlyCallableMoveConstruction) {
     EXPECT_EQ(f2(), 43);
 }
 
-TEST(FixedFunctionTest, MoveOnlyCallableCopyYieldsEmpty) {
+TEST(FixedFunctionTest, MoveOnlyCallableCopyTriggersAssert) {
     fixed_function<int()> f1(MoveOnlyCallable(42));
-    fixed_function<int()> f2(f1);
-    EXPECT_FALSE(f2);
+    EXPECT_DEATH({ fixed_function<int()> f2(f1); },
+                 "Assertion.*failed");
 }
 
 TEST(FixedFunctionTest, AssignNullptr) {

--- a/tests/test_freertos_once_flag.cpp
+++ b/tests/test_freertos_once_flag.cpp
@@ -23,6 +23,16 @@ protected:
 
   StrictMock<FreeRTOSMock> *mock;
   int counter;
+
+  static void set_initialized(freertos::once_flag &flag) {
+    flag.m_state.store(2, std::memory_order_release);
+  }
+
+#if configSUPPORT_STATIC_ALLOCATION
+  static void set_initialized(freertos::sa::once_flag_static &flag) {
+    flag.m_state.store(2, std::memory_order_release);
+  }
+#endif
 };
 
 TEST_F(OnceFlagTest, IsInitialized_DefaultFalse) {
@@ -34,9 +44,11 @@ TEST_F(OnceFlagTest, CallOnce_ExecutesFunction) {
   freertos::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   freertos::call_once(flag, [this]() { counter++; });
@@ -48,9 +60,11 @@ TEST_F(OnceFlagTest, CallOnce_ExecutesOnlyOnce) {
   freertos::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   freertos::call_once(flag, [this]() { counter++; });
@@ -64,9 +78,11 @@ TEST_F(OnceFlagTest, CallOnce_WithLambda) {
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
   int value = 0;
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   freertos::call_once(flag, [&value]() { value = 42; });
@@ -78,9 +94,11 @@ TEST_F(OnceFlagTest, CallOnce_WithFunctionPointer) {
   freertos::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   static int global_val;
@@ -100,9 +118,11 @@ TEST_F(OnceFlagTest, CallOnce_WithFunctionObject) {
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
   int value = 0;
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   Functor f{value};
@@ -120,9 +140,12 @@ TEST_F(OnceFlagTest, StaticAllocation_CallOnce) {
   freertos::sa::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   int value = 0;
   freertos::sa::call_once(flag, [&value]() { value = 55; });
@@ -134,9 +157,12 @@ TEST_F(OnceFlagTest, StaticAllocation_CallOnceOnlyOnce) {
   freertos::sa::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   int value = 0;
   freertos::sa::call_once(flag, [&value]() { value++; });
@@ -149,9 +175,11 @@ TEST_F(OnceFlagTest, CallOnce_ThrowsException_Rethrows) {
   freertos::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   EXPECT_THROW(
@@ -167,9 +195,11 @@ TEST_F(OnceFlagTest, CallOnce_ThrowsException_RetrySucceeds) {
 
   {
     ::testing::InSequence s;
-    EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+    EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
         .WillOnce(Return(sem));
-    EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+    EXPECT_CALL(*mock, xSemaphoreGive(sem))
+        .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+        .WillRepeatedly(Return(pdTRUE));
   }
 
   EXPECT_THROW(
@@ -177,7 +207,9 @@ TEST_F(OnceFlagTest, CallOnce_ThrowsException_RetrySucceeds) {
       std::runtime_error);
   EXPECT_FALSE(flag.is_initialized());
 
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   freertos::call_once(flag, [&value]() { value = 42; });
@@ -189,12 +221,16 @@ TEST_F(OnceFlagTest, CallOnce_WaiterPath) {
   freertos::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  ::testing::InSequence seq;
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
   EXPECT_CALL(*mock, xSemaphoreTake(sem, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+      .WillOnce(::testing::Invoke([&flag]() -> BaseType_t {
+        set_initialized(flag);
+        return pdTRUE;
+      }));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   bool inner_called = false;
@@ -209,12 +245,16 @@ TEST_F(OnceFlagTest, CallOnce_WaiterPathThenSubsequentCallReturnsEarly) {
   freertos::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  ::testing::InSequence seq;
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
   EXPECT_CALL(*mock, xSemaphoreTake(sem, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+      .WillOnce(::testing::Invoke([&flag]() -> BaseType_t {
+        set_initialized(flag);
+        return pdTRUE;
+      }));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   int counter = 0;
@@ -233,12 +273,17 @@ TEST_F(OnceFlagTest, StaticAllocation_CallOnceWaiterPath) {
   freertos::sa::once_flag flag;
   SemaphoreHandle_t sem = reinterpret_cast<SemaphoreHandle_t>(0x1);
 
-  ::testing::InSequence seq;
-  EXPECT_CALL(*mock, xSemaphoreCreateBinaryStatic(_))
+  EXPECT_CALL(*mock, xSemaphoreCreateCountingStatic(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS, 0, _))
       .WillOnce(Return(sem));
   EXPECT_CALL(*mock, xSemaphoreTake(sem, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGive(sem)).WillOnce(Return(pdTRUE));
+      .WillOnce(::testing::Invoke([&flag]() -> BaseType_t {
+        set_initialized(flag);
+        return pdTRUE;
+      }));
+  EXPECT_CALL(*mock, xSemaphoreGive(sem))
+      .Times(FREERTOS_CPP_WRAPPERS_ONCE_FLAG_MAX_WAITERS)
+      .WillRepeatedly(Return(pdTRUE));
+  EXPECT_CALL(*mock, vSemaphoreDelete(sem));
 
   bool inner_called = false;
   freertos::sa::call_once(flag, [&]() {

--- a/tests/test_freertos_semaphore.cpp
+++ b/tests/test_freertos_semaphore.cpp
@@ -396,10 +396,6 @@ TEST_F(FreeRTOSSemaphoreTest, MutexLockWithTimeout) {
 TEST_F(FreeRTOSSemaphoreTest, MutexISROperations) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, NotNull()))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, NotNull()))
-      .WillOnce(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mutex;
@@ -407,8 +403,8 @@ TEST_F(FreeRTOSSemaphoreTest, MutexISROperations) {
   auto lock_result = mutex.lock_isr();
   auto unlock_result = mutex.unlock_isr();
 
-  EXPECT_EQ(lock_result.result, pdTRUE);
-  EXPECT_EQ(unlock_result.result, pdTRUE);
+  EXPECT_EQ(lock_result.result, pdFALSE);
+  EXPECT_EQ(unlock_result.result, pdFALSE);
 }
 
 // =============================================================================
@@ -1090,33 +1086,18 @@ TEST_F(FreeRTOSSemaphoreTest, TryLockGuardFailure) {
 TEST_F(FreeRTOSSemaphoreTest, LockGuardISRRAII) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock,
-              xSemaphoreTakeFromISR(mock_mutex_handle, ::testing::NotNull()))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock,
-              xSemaphoreGiveFromISR(mock_mutex_handle, ::testing::NotNull()))
-      .WillOnce(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mutex;
 
   {
-    /*
-     * ISR Lock Guard Test:
-     * This tests the lock_guard_isr which is designed for use in ISR contexts.
-     * In a real FreeRTOS environment, this would be used inside interrupt
-     * service routines. Here we test the API compatibility and parameter
-     * passing.
-     */
     freertos::lock_guard_isr<
         freertos::mutex<freertos::dynamic_semaphore_allocator>>
         guard(mutex);
-    // Mutex should be locked here
-    EXPECT_TRUE(mutex.locked());
-    EXPECT_TRUE(guard.locked());
-    // Check if high priority task woken flag is accessible
+    EXPECT_FALSE(mutex.locked());
+    EXPECT_FALSE(guard.locked());
     EXPECT_EQ(guard.high_priority_task_woken(), pdFALSE);
-  } // ISR lock guard destructor should unlock the mutex
+  }
 
   EXPECT_FALSE(mutex.locked());
 }
@@ -2010,54 +1991,27 @@ TEST_F(FreeRTOSSemaphoreTest, MutexLockWithTimeoutFails_BranchCoverage) {
   EXPECT_FALSE(m.locked());
 }
 
-TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrFails_BranchCoverage) {
+TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdFAIL));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> m;
-  EXPECT_EQ(m.lock_isr().result, pdFALSE);
+  auto result = m.lock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+  EXPECT_FALSE(m.locked());
 }
 
-TEST_F(FreeRTOSSemaphoreTest, MutexUnlockIsrFails_BranchCoverage) {
+TEST_F(FreeRTOSSemaphoreTest, MutexUnlockIsrReturnsFailure) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex_handle, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdFAIL));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> m;
-  m.lock();
-  EXPECT_EQ(m.unlock_isr().result, pdFAIL);
-}
-
-TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrNoWoken_BranchCoverage) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex())
-      .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
-
-  freertos::mutex<freertos::dynamic_semaphore_allocator> m;
-  EXPECT_EQ(m.lock_isr().result, pdTRUE);
-}
-
-TEST_F(FreeRTOSSemaphoreTest, MutexUnlockIsrNoWoken_BranchCoverage) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex())
-      .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex_handle, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
-
-  freertos::mutex<freertos::dynamic_semaphore_allocator> m;
-  m.lock();
-  EXPECT_EQ(m.unlock_isr().result, pdTRUE);
+  auto result = m.unlock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(FreeRTOSSemaphoreTest, MutexTimeoutLockGuardChrono_BranchCoverage) {
@@ -2196,27 +2150,23 @@ TEST_F(FreeRTOSSemaphoreTest, MutexDestructionNullHandle_BranchCoverage) {
 TEST_F(FreeRTOSSemaphoreTest, MutexUnlockIsrNoWokenFailure_BranchCoverage) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTake(mock_mutex_handle, portMAX_DELAY))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
-  mtx.lock();
-  EXPECT_EQ(mtx.unlock_isr().result, pdFALSE);
-  EXPECT_TRUE(mtx.locked());
+  auto result = mtx.unlock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrNoWokenFailure_BranchCoverage) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
-  EXPECT_EQ(mtx.lock_isr().result, pdFALSE);
+  auto result = mtx.lock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 
@@ -2257,19 +2207,16 @@ TEST_F(FreeRTOSSemaphoreTest, BinarySemaphoreTakeIsrWithWoken_BranchCoverage) {
 TEST_F(FreeRTOSSemaphoreTest, MutexUnlockIsrNoArg_BranchCoverage) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdTRUE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
-  auto result = mtx.lock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_TRUE(mtx.locked());
-  result = mtx.unlock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
+  auto lock_result = mtx.lock_isr();
+  EXPECT_EQ(lock_result.result, pdFALSE);
+  EXPECT_EQ(lock_result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
+  auto unlock_result = mtx.unlock_isr();
+  EXPECT_EQ(unlock_result.result, pdFALSE);
+  EXPECT_EQ(unlock_result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(FreeRTOSSemaphoreTest,
@@ -2390,39 +2337,35 @@ TEST_F(FreeRTOSSemaphoreTest, BinarySemaphoreTakeChrono_BranchCoverage) {
 TEST_F(FreeRTOSSemaphoreTest, MutexUnlockIsrFailure_BranchCoverage) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreGiveFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
   auto result = mtx.unlock_isr();
   EXPECT_EQ(result.result, pdFALSE);
-  EXPECT_FALSE(mtx.locked());
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
 }
 
 TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrNoArg_BranchCoverage) {
   EXPECT_CALL(*mock, xSemaphoreCreateMutex())
       .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdTRUE));
-  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
-
-  freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
-  auto result = mtx.lock_isr();
-  EXPECT_EQ(result.result, pdTRUE);
-  EXPECT_TRUE(mtx.locked());
-}
-
-TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrNoArgFailure_BranchCoverage) {
-  EXPECT_CALL(*mock, xSemaphoreCreateMutex())
-      .WillOnce(Return(mock_mutex_handle));
-  EXPECT_CALL(*mock, xSemaphoreTakeFromISR(mock_mutex_handle, _))
-      .WillOnce(Return(pdFALSE));
   EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
 
   freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
   auto result = mtx.lock_isr();
   EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
+  EXPECT_FALSE(mtx.locked());
+}
+
+TEST_F(FreeRTOSSemaphoreTest, MutexLockIsrNoArgFailure_BranchCoverage) {
+  EXPECT_CALL(*mock, xSemaphoreCreateMutex())
+      .WillOnce(Return(mock_mutex_handle));
+  EXPECT_CALL(*mock, vSemaphoreDelete(mock_mutex_handle));
+
+  freertos::mutex<freertos::dynamic_semaphore_allocator> mtx;
+  auto result = mtx.lock_isr();
+  EXPECT_EQ(result.result, pdFALSE);
+  EXPECT_EQ(result.higher_priority_task_woken, pdFALSE);
   EXPECT_FALSE(mtx.locked());
 }
 

--- a/tests/test_freertos_sw_timer.cpp
+++ b/tests/test_freertos_sw_timer.cpp
@@ -1667,8 +1667,9 @@ TEST_F(FreeRTOSSwTimerTest, DynamicTimerSwap) {
 // BUG FIX REGRESSION TESTS
 // =============================================================================
 
-// Issue #121: m_started data race between ISR and task context
-// Verify that start/stop correctly manage m_started (which is volatile-qualified).
+// Issue #172 (was #121): m_started data race between ISR and task context
+// Verify that start/stop correctly manage m_started (which is now
+// std::atomic<bool> for SMP-safe access).
 TEST_F(FreeRTOSSwTimerTest, Issue121VolatileStartedFlag) {
   EXPECT_CALL(*mock, xTimerCreateStatic(_, _, _, _, _, _))
       .WillOnce(Return(mock_timer_handle));


### PR DESCRIPTION
## Summary

This PR supersedes #196, which cannot be merged cleanly because `origin/main` (`b799d70`) was force-updated to a squashed single commit that has the same tree content but different history from the feature branch.

This branch (`merge-v3.2.0`) applies the **identical net changes** as a single clean commit on top of the current `origin/main`.

### Changes
All design review fixes (#167-#195) and PR review fixes (#197-#212) are included. See the original #196 for full details.

Key fixes:
- `once_flag`: counting semaphore for multi-waker support (#167)
- `timer::m_started`: `std::atomic<bool>` for SMP safety (#172)
- `condition_variable_any`: `m_waiter_count` + overflow configASSERT (#200)
- `gthr`: atomic `waiter_count` lost-wakeup fix (#211)
- CMake install rules restored (#206)
- ISR safety fixes across semaphores/mutexes (#179-#180)

### Tests
- **85/85 tests pass** (all unit test targets)
- Coverage targets met (verified in #196)

### Verification
All changes match the approved content from `feature/v3.1.0-sim2` (b643991).